### PR TITLE
db-9856 - Add partial support for setQueryTimeout()

### DIFF
--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -1025,15 +1025,10 @@ public class CLI {
 			return;
 		}
 		try {
-			final Statement stmt = conn.createStatement();
 			start = System.currentTimeMillis();
 			final int timeout = Integer.parseInt(cmd.substring("SET TIMEOUT ".length()).trim());
-			((XGStatement) stmt).setQueryTimeout(timeout);
-			printWarnings(stmt);
+			((XGConnection)conn).setTimeout(timeout);
 			end = System.currentTimeMillis();
-
-			stmt.close();
-
 			printTime(start, end);
 		} catch (final Exception e) {
 			System.out.println("CLI Error: " + e.getMessage());

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -271,6 +271,8 @@ public class CLI {
 			forceExternal(cmd);
 		} else if (startsWithIgnoreCase(cmd, "EXPORT TABLE")) {
 			exportTable(cmd);
+		} else if (startsWithIgnoreCase(cmd, "SET TIMEOUT")) {
+			setQueryTimeout(cmd);
 		} else {
 			System.out.println("Invalid command: " + cmd);
 		}
@@ -1004,6 +1006,29 @@ public class CLI {
 			start = System.currentTimeMillis();
 			final String uuid = cmd.substring("CANCEL ".length()).trim();
 			((XGStatement) stmt).cancelQuery(uuid);
+			printWarnings(stmt);
+			end = System.currentTimeMillis();
+
+			stmt.close();
+
+			printTime(start, end);
+		} catch (final Exception e) {
+			System.out.println("CLI Error: " + e.getMessage());
+		}
+	}
+
+	private static void setQueryTimeout(final String cmd) {
+		long start = 0;
+		long end = 0;
+		if (!isConnected()) {
+			System.out.println("No database connection exists");
+			return;
+		}
+		try {
+			final Statement stmt = conn.createStatement();
+			start = System.currentTimeMillis();
+			final int timeout = Integer.parseInt(cmd.substring("SET TIMEOUT ".length()).trim());
+			((XGStatement) stmt).setQueryTimeout(timeout);
 			printWarnings(stmt);
 			end = System.currentTimeMillis();
 

--- a/src/main/java/com/ocient/jdbc/JDBCDriver.java
+++ b/src/main/java/com/ocient/jdbc/JDBCDriver.java
@@ -26,11 +26,6 @@ public class JDBCDriver implements Driver
 	private String logFileName;
 	private FileHandler logHandler;
 
-	// Only create if timeout is actually set.
-	// FIXME 1 driver per process, right?
-	// FIXME do driver's have a teardown routine? Do we need to manage lifecycle here?
-	private final AtomicReference<Timer> timer = new AtomicReference<>();
-
 	static
 	{
 		try
@@ -114,7 +109,7 @@ public class JDBCDriver implements Driver
 			}
 
 			return new XGConnection(sock, arg1.getProperty("user"), arg1.getProperty("password"), portNum, arg0, db,
-					version, arg1.getProperty("force", "false"), this::getTimer);
+					version, arg1.getProperty("force", "false"));
 		}
 		catch (final Exception e)
 		{
@@ -125,13 +120,6 @@ public class JDBCDriver implements Driver
 			
 			throw SQLStates.newGenericException(e);
 		}
-	}
-
-	/**
-	 * Creates a new {@link Timer} or returns the existing one if it already exists
-	 */
-	private Timer getTimer() {
-		return this.timer.updateAndGet(existing -> existing != null ? existing : new Timer());
 	}
 
 	public String getDriverVersion() {

--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -137,6 +137,7 @@ public class XGConnection implements Connection
 	protected String version;
 	protected String setSchema = "";
 	protected boolean force = false;
+	private volatile long timeoutMillis = 0L; // 0L means no timeout set
 
 	protected boolean oneShotForce = false;
 	protected ArrayList<String> cmdcomps = new ArrayList<>();
@@ -204,6 +205,20 @@ public class XGConnection implements Connection
 		}
 
 		warnings.clear();
+	}
+
+	/*!
+	 * This timeout will be applied to every XGStatement created
+	 */
+	public void setTimeout(final int seconds) throws SQLException {
+		if (seconds < 0) {
+			throw new SQLWarning(String.format("timeout value must be non-negative, was: %s", seconds));
+		}
+		this.timeoutMillis = seconds * 1000;
+	}
+
+	protected long getTimeoutMillis() {
+		return timeoutMillis;
 	}
 
 	/**

--- a/src/main/java/com/ocient/jdbc/XGResultSet.java
+++ b/src/main/java/com/ocient/jdbc/XGResultSet.java
@@ -807,19 +807,19 @@ public class XGResultSet implements ResultSet
 			conn.out.flush();
 
 			// Kind of ugly, but doesn't violate JMM (startTask() is synchronous)
-			final ClientWireProtocol.FetchDataResponse.Builder[] fdr = {ClientWireProtocol.FetchDataResponse.newBuilder()};
+			final ClientWireProtocol.FetchDataResponse.Builder fdr = ClientWireProtocol.FetchDataResponse.newBuilder();
 			stmt.startTask(() -> {
 				// get confirmation and data (fetchSize rows or zero size result set or terminated early with a DataEndMarker)
 				final int length = getLength();
 				final byte[] data = new byte[length];
 				readBytes(data);
-				fdr[0].mergeFrom(data);
+				fdr.mergeFrom(data);
 			}, queryId, getTimeoutMillis());
 
-			final ConfirmationResponse response = fdr[0].getResponse();
+			final ConfirmationResponse response = fdr.getResponse();
 			final ResponseType rType = response.getType();
 			processResponseType(rType, response);
-			return mergeData(fdr[0].getResultSet());
+			return mergeData(fdr.getResultSet());
 		}
 		catch (final Exception e)
 		{

--- a/src/main/java/com/ocient/jdbc/XGResultSet.java
+++ b/src/main/java/com/ocient/jdbc/XGResultSet.java
@@ -66,7 +66,6 @@ public class XGResultSet implements ResultSet
 	private Map<String, Integer> cols2Pos;
 	private TreeMap<Integer, String> pos2Cols;
 	private Map<String, String> cols2Types;
-	private final long timeoutMillis; // timeout used for every invocation of getMoreData()
 
 	//tell whether the resultset was constructed with a pre-defined dataset.    
 	private boolean immutable = false;	
@@ -81,7 +80,6 @@ public class XGResultSet implements ResultSet
 		this.fetchSize = fetchSize;
 		this.stmt = stmt;
 		requestMetaData();
-		timeoutMillis = stmt.getQueryTimeoutMillis();
 	}
 	
 	public XGResultSet(final XGConnection conn, final ArrayList<Object> rs, final XGStatement stmt)
@@ -91,7 +89,6 @@ public class XGResultSet implements ResultSet
 		this.stmt = stmt;
 		this.rs.add(new DataEndMarker());
 		this.immutable = true;
-		timeoutMillis = stmt.getQueryTimeoutMillis();
 	}	
 	
 	public XGResultSet(final XGConnection conn, final int fetchSize, final XGStatement stmt,
@@ -102,13 +99,16 @@ public class XGResultSet implements ResultSet
 		this.stmt = stmt;
 		requestMetaData();
 		mergeData(re);
-		timeoutMillis = stmt.getQueryTimeoutMillis();
 	}
 
 	private Optional<String> getQueryId() {
 		// TODO The query id should be known when the result set is created (on executeQuery())
 		// but this would require some additional server side work, so we'll do this hac for now
 		return stmt.getQueryId();
+	}
+
+	private long getTimeoutMillis() {
+		return stmt.getQueryTimeoutMillis();
 	}
 
 	@Override
@@ -814,7 +814,7 @@ public class XGResultSet implements ResultSet
 				final byte[] data = new byte[length];
 				readBytes(data);
 				fdr[0].mergeFrom(data);
-			}, queryId, timeoutMillis);
+			}, queryId, getTimeoutMillis());
 
 			final ConfirmationResponse response = fdr[0].getResponse();
 			final ResponseType rType = response.getType();

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -184,6 +184,8 @@ public class XGStatement implements Statement
 	 * @throws SQLTimeoutException if the timeout is reached before the call completes
 	 */
 	protected void startTask(ExceptionalRunnable task, Optional<String> optQueryId, final long timeoutMillis) throws Exception {
+		Preconditions.checkArgument(timeoutMillis >= 0L);
+		
 		// Check if we even have a cancelable query at this point
 		if (!optQueryId.isPresent()) {
 			task.run();
@@ -230,8 +232,6 @@ public class XGStatement implements Statement
 				}
 			};
 			
-		// Make our current state visible to the timeout thread
-		Preconditions.checkArgument(timeoutMillis >= 0L);
 		conn.addTimeout(killQueryTask, timeoutMillis);
 
 		try {

--- a/src/main/proto/ClientWireProtocol.proto
+++ b/src/main/proto/ClientWireProtocol.proto
@@ -152,6 +152,7 @@ message ExecuteQueryResponse
 	bool redirect = 2; //Redirect = true, means we are telling client to send the command elsewhere
 	string redirectHost = 3;
 	fixed32 redirectPort = 4;
+	string queryId = 5; // The query ID (generated server side) can be used by a client to cancel/kill
 }
 
 message ExecuteUpdate


### PR DESCRIPTION
### Overview
Timeouts are not enforced on the initial call to `executeQuery()` but are for every subsequent fetch from the server. 

- See c532ec1 to see timeout invoking implementation
- See df2ea6e to see the only use case (for now) `ResultSet.next()`

### Gotchas

- ~The driver uses a single Timer (thread) for all connections. This might be a problem as the kill query message could potentially hang, effectively disabling timeout functionality on all connections. The timer queue depth is still bounded by the number of open connections so we shouldn't have to worry about gc death spirals here (max 1 outstanding timeout task per connection).~
- ~I HAVE NOT TESTED ANY OF THIS (OMG). I'll need @leogreca's help on how to do this. (He already showed me how to do this, but my memory has never been great and I'm getting old)~