### PR TITLE
Allow comma-separated hosts lists in connection string

### DIFF
--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -325,7 +325,6 @@ public class CLI {
 	}
 
 	private static Pattern connectToSyntax = Pattern.compile(
-			// "connect to (?<url>.+?)(?<up> user (" + userTk() + ") using (?<q>\"?)(?<pwd>.+?)\\k<q>)?(?<force> force)?",
 			"connect to (?<preurl>jdbc:ocient://?)(?<hosts>.+?)(?<posturl>/.+?)(?<up> user (" + userTk() + ") using (?<q>\"?)(?<pwd>.+?)\\k<q>)?(?<force> force)?",
 			Pattern.CASE_INSENSITIVE);
 

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -347,6 +347,7 @@ public class CLI {
 			final String[] hosts = m.group("hosts").split(",");
 			final String preurl = m.group("preurl");
 			final String posturl = m.group("posturl");
+			Exception lastException = null;
 			for (String host : hosts) {
 				final String url = preurl + host + posturl;
 				try {
@@ -355,13 +356,16 @@ public class CLI {
 					} else {
 						doConnect(getTk(m, "user", null), m.group("pwd"), (m.group("force") != null), url);
 					}
+					// No exception thrown means connection was successful, and connectTo may return
+					System.out.println("Connected to " + url);
+					return;
 				} catch (final Exception e) {
 					System.out.println("Failed to connect to " + host);
-					continue;
+					lastException = e;
 				}
-				// No exception thrown means connection was successful, and connectTo may return
-				System.out.println("Connected to " + url);
-				return;
+			}
+			if (lastException != null) {
+				throw lastException;
 			}
 		} catch (final Exception e) {
 			System.out.println("Error: " + e.getMessage());

--- a/src/main/java/com/ocient/jdbc/JDBCDriver.java
+++ b/src/main/java/com/ocient/jdbc/JDBCDriver.java
@@ -86,14 +86,14 @@ public class JDBCDriver implements Driver
 			Socket sock = null;
 			try
 			{
-				sock = new Socket();
-				sock.setReceiveBufferSize(4194304);
-				sock.setSendBufferSize(4194304);
 				final InetAddress[] addrs = InetAddress.getAllByName(hostname);
 				boolean connected = false;
 				Throwable lastError = null;
 				for (InetAddress addr : addrs) {
 					try {
+						sock = new Socket();
+						sock.setReceiveBufferSize(4194304);
+						sock.setSendBufferSize(4194304);
 						sock.connect(new InetSocketAddress(addr, portNum), 10000);
 						connected = true;
 						break;


### PR DESCRIPTION
DB-10120
DB-10119
Example:
```
Ocient> connect to jdbc:ocient://localhost:4050,localhost:4051/test;
Failed to connect to localhost:4050
Connected to jdbc:ocient://localhost:4051/test
Ocient> 
```