### PR TITLE
Make default schema/table for fetch metadata a wildcard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ocient</groupId>
   <artifactId>ocient-jdbc4</artifactId>
-  <version>1.16</version> <!--JDBC VERSION NUMBER HERE-->
+  <version>1.17</version> <!--JDBC VERSION NUMBER HERE-->
   <name>${project.groupId}:${project.artifactId}</name>
   <description>JDBC Driver for connecting to an Ocient Database</description>
   <url>http://www.ocient.com</url>

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -745,6 +745,10 @@ public class XGStatement implements Statement
 			{
 				b1.setSchema(schema);
 			}
+			else
+			{
+				b1.setSchema("%");
+			}
 			if ((call == FetchSystemMetadata.SystemMetadataCall.GET_VIEWS) && (table != null) && (!table.equals("")))
 			{
 				b1.setView(table);
@@ -752,6 +756,10 @@ public class XGStatement implements Statement
 			else if ((table != null) && (!table.equals("")))
 			{
 				b1.setTable(table);
+			}
+			else
+			{
+				b1.setTable("%");
 			}
 			if ((col != null) && (!col.equals("")))
 			{
@@ -1430,7 +1438,7 @@ public class XGStatement implements Statement
                                 final TimeZone utc = TimeZone.getTimeZone("UTC");
                                 format.setTimeZone(utc);
                                 out += ("TIME('" + format.format((Time) parm) + "')");
-                            } 
+                            }
                             else if (parm instanceof Byte)
                             {
                             	out += ("BYTE(" + parm + ")");
@@ -1455,7 +1463,7 @@ public class XGStatement implements Statement
                             {
                             	out += ("DECIMAL(" + parm + ", " + ((BigDecimal)parm).precision() + ", " + ((BigDecimal)parm).scale() + ")");
                             }
-                            else 
+                            else
                             {
                             	throw new SQLFeatureNotSupportedException();
                             }

--- a/upload_jar.sh
+++ b/upload_jar.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: PROG <VERSION_NUMBER>"
+    exit 1
+fi
+
+VERSION=$1
+VERSION_DIR=v$VERSION
+
+cd target
+rm -rf $VERSION_DIR
+mkdir $VERSION_DIR
+cp ocient-jdbc4-$VERSION-jar-with-dependencies.jar $VERSION_DIR
+scp -r $VERSION_DIR user@ocient-archive:/home/user/www/ocientrepo/java/jdbc/


### PR DESCRIPTION
Right now we don't specify schema through Tableau, so they pass the driver `""` as the schema name.  This results in users being unable to find the correct tables through the Tableau search bar.