### PR TITLE
DB-10899: Fix close method on XgConnection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ocient</groupId>
   <artifactId>ocient-jdbc4</artifactId>
-  <version>1.16</version> <!--JDBC VERSION NUMBER HERE-->
+  <version>1.17</version> <!--JDBC VERSION NUMBER HERE-->
   <name>${project.groupId}:${project.artifactId}</name>
   <description>JDBC Driver for connecting to an Ocient Database</description>
   <url>http://www.ocient.com</url>

--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -442,7 +442,7 @@ public class XGConnection implements Connection
 			return;
 		}
 
-		if (rs != null)
+		if (rs != null && !rs.isClosed())
 		{
 			rs.getStatement().cancel();
 		}


### PR DESCRIPTION
When the named plan tests go to close a connection, it throws an exception on the result set since it was already closed.

I'm not sure if this actually matters, but it was annoying seeing this warning after every test.

> WARNING: Could not close connection to db
java.sql.SQLException: A client method was called on a closed object
	at com.ocient.jdbc.SQLStates.clone(SQLStates.java:431)
	at com.ocient.jdbc.XGResultSet.getStatement(XGResultSet.java:1215)
	at com.ocient.jdbc.XGConnection.close(XGConnection.java:447)
	at com.ocient.cs.DbInstance.closeConn(DbInstance.java:143)
	at com.ocient.cs.job.CsJob.run(CsJob.java:130)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:830)
