### PR TITLE
[DB-11897] fix weird message from diver and add proper message

### DIFF
--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -199,7 +199,7 @@ public class XGConnection implements Connection {
 	}
 
 	@SuppressWarnings("unchecked")
-	public XGConnection copy() {
+	public XGConnection copy() throws SQLException{
 		XGConnection retval = new XGConnection(user, pwd, portNum, url, database, version, force);
 		try {
 			retval.connected = false;
@@ -212,12 +212,13 @@ public class XGConnection implements Connection {
 			retval.reconnect();
 		} catch (Exception e) {
 			LOGGER.log(Level.SEVERE,
-					String.format("Copying the connection for a new statement failed with exception %s with message %",
+					String.format("Copying the connection for a new statement failed with exception %s with message %s",
 							e.toString(), e.getMessage()));
 			try {
 				retval.close();
 			} catch (Exception f) {
 			}
+			throw new SQLException(e);
 		}
 
 		return retval;
@@ -1323,8 +1324,7 @@ public class XGConnection implements Connection {
 		if (retVal != null) {
 			throw retVal;
 		}
-		
-		throw new IOException();
+		throw new IOException("Failed to reconnect.");
 	}
 
 	/*

--- a/src/main/java/com/ocient/jdbc/XGPreparedStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGPreparedStatement.java
@@ -29,19 +29,19 @@ public class XGPreparedStatement extends XGStatement implements PreparedStatemen
 	private final String sql;
 
 	public XGPreparedStatement(final XGConnection conn, final String sql, final boolean force,
-			final boolean oneShotForce) {
+			final boolean oneShotForce) throws SQLException {
 		super(conn, force, oneShotForce);
 		this.sql = sql;
 	}
 
 	public XGPreparedStatement(final XGConnection conn, final String sql, final int arg1, final int arg2,
-			final boolean force, final boolean oneShotForce) throws SQLFeatureNotSupportedException {
+			final boolean force, final boolean oneShotForce) throws SQLException {
 		super(conn, arg1, arg2, force, oneShotForce);
 		this.sql = sql;
 	}
 
 	public XGPreparedStatement(final XGConnection conn, final String sql, final int arg1, final int arg2,
-			final int arg3, final boolean force, final boolean oneShotForce) throws SQLFeatureNotSupportedException {
+			final int arg3, final boolean force, final boolean oneShotForce) throws SQLException {
 		super(conn, arg1, arg2, arg3, force, oneShotForce);
 		this.sql = sql;
 	}

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -126,7 +126,7 @@ public class XGStatement implements Statement {
 
 	private boolean oneShotForce;
 
-	public XGStatement(final XGConnection conn, final boolean force, final boolean oneShotForce) {
+	public XGStatement(final XGConnection conn, final boolean force, final boolean oneShotForce) throws SQLException {
 		this.conn = conn.copy();
 		this.force = force;
 		this.oneShotForce = oneShotForce;
@@ -134,7 +134,7 @@ public class XGStatement implements Statement {
 	}
 
 	public XGStatement(final XGConnection conn, final int type, final int concur, final boolean force,
-			final boolean oneShotForce) throws SQLFeatureNotSupportedException {
+			final boolean oneShotForce) throws SQLException {
 		this.conn = conn.copy();
 		this.force = force;
 		this.oneShotForce = oneShotForce;
@@ -151,7 +151,7 @@ public class XGStatement implements Statement {
 	}
 
 	public XGStatement(final XGConnection conn, final int type, final int concur, final int hold, final boolean force,
-			final boolean oneShotForce) throws SQLFeatureNotSupportedException {
+			final boolean oneShotForce) throws SQLException {
 		this.conn = conn.copy();
 		this.force = force;
 		this.oneShotForce = oneShotForce;


### PR DESCRIPTION
https://jira.ocient.com:8443/browse/DB-11897

In copy, there was a missing 's' next to the '%'.  However, as it stands, when copy() calls reconnect(), reconnect throws an exception with an empty message. If we want to bubble a proper message all the way back up, I had to change copy() to throw an exception. Or I could forgo any changes to exception signatures and leave the message blank. A proper message still gets logged.