### PR TITLE
[DB-11653] move a lot of functions into the driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ocient</groupId>
 	<artifactId>ocient-jdbc4</artifactId>
-	<version>1.41</version> <!--JDBC VERSION NUMBER HERE -->
+	<version>1.42</version> <!--JDBC VERSION NUMBER HERE -->
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>JDBC Driver for connecting to an Ocient Database</description>
 	<url>http://www.ocient.com</url>

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -990,7 +990,6 @@ public class CLI {
 				System.out.println(planLine);
 			}
 			rs.close();
-			//System.out.println(pm);
 			
 			printWarnings(stmt);
 			end = System.currentTimeMillis();

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -288,7 +288,7 @@ public class CLI {
 		} else if (startsWithIgnoreCase(cmd, "KILL")) {
 			killQuery(cmd);
 		} else if (startsWithIgnoreCase(cmd, "LIST ALL QUERIES")) {
-			listAllQueries();
+			listAllQueries(cmd);
 		} else if (startsWithIgnoreCase(cmd, "OUTPUT NEXT QUERY")) {
 			outputNextQuery(cmd);
 		} else if (startsWithIgnoreCase(cmd, "FORCE EXTERNAL")) {
@@ -429,13 +429,21 @@ public class CLI {
 			return;
 		}
 
+		ResultSet rs = null;
 		try {
-			String schema = conn.getSchema();
-			if (!schema.toLowerCase().equals(schema)) {
-				schema = "\"" + schema + "\"";
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
+			while (rs.next()) {
+				String planLine = rs.getString(1);
+				System.out.println(planLine);
 			}
-			System.out.println(schema);
+			rs.close();
 		} catch (final Exception e) {
+			e.printStackTrace();
+			try {
+				rs.close();
+			} catch (Exception f) {
+			}
 			System.out.println("Error: " + e.getMessage());
 		}
 	}
@@ -445,18 +453,8 @@ public class CLI {
 			System.out.println("No database connection exists");
 			return;
 		}
-
 		try {
-			String schema = cmd.substring(11).trim();
-			if (schema.startsWith("\"")) {
-				if (!schema.endsWith("\"")) {
-					System.out.println("Unclosed quotes!");
-					return;
-				}
-
-				schema = schema.substring(1, schema.length() - 1);
-			}
-			conn.setSchema(schema);
+			stmt.execute(cmd);
 		} catch (final Exception e) {
 			System.out.println("Error: " + e.getMessage());
 		}
@@ -505,12 +503,8 @@ public class CLI {
 			}
 
 			start = System.currentTimeMillis();
-			if (isSystemTables) {
-				final XGDatabaseMetaData xgdbmd = (XGDatabaseMetaData) dbmd;
-				rs = xgdbmd.getSystemTables("", "%", "%", new String[0]);
-			} else {
-				rs = dbmd.getTables("", "%", "%", new String[0]);
-			}
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 			final ResultSetMetaData meta = rs.getMetaData();
 
 			if (m.group("verbose") != null) {
@@ -571,14 +565,24 @@ public class CLI {
 			System.out.println("No database connection exists");
 			return;
 		}
+		ResultSet rs = null;
 		try {
 			start = System.currentTimeMillis();
-			System.out.println(((XGStatement) stmt).exportTable(cmd));
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
+			while (rs.next()) {
+				String exportLine = rs.getString(1);
+				System.out.println(exportLine);
+			}
 			printWarnings(stmt);
 			end = System.currentTimeMillis();
-
+			rs.close();
 			printTime(start, end);
 		} catch (final Exception e) {
+			try{
+				rs.close();
+			} catch(final Exception f){
+			}
 			System.out.println("Error: " + e.getMessage());
 		}
 	}
@@ -607,7 +611,8 @@ public class CLI {
 			}
 
 			start = System.currentTimeMillis();
-			rs = dbmd.getViews("", "%", "%", new String[0]);
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 			final ResultSetMetaData meta = rs.getMetaData();
 
 			if (m.group("verbose") != null) {
@@ -664,8 +669,8 @@ public class CLI {
 			}
 
 			start = System.currentTimeMillis();
-			final DatabaseMetaData dbmd = conn.getMetaData();
-			rs = dbmd.getColumns("", getTk(m, "schema", conn.getSchema()), getTk(m, "table", null), "%");
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 			final ResultSetMetaData meta = rs.getMetaData();
 
 			if (m.group("verbose") != null) {
@@ -745,9 +750,8 @@ public class CLI {
 			}
 
 			start = System.currentTimeMillis();
-			final DatabaseMetaData md = conn.getMetaData();
-			final XGDatabaseMetaData dbmd = (XGDatabaseMetaData) md;
-			rs = dbmd.getViews("", getTk(m, "schema", conn.getSchema()), getTk(m, "view", null), null);
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 			final ResultSetMetaData meta = rs.getMetaData();
 
 			if (m.group("verbose") != null)
@@ -801,11 +805,12 @@ public class CLI {
 			}
 
 			start = System.currentTimeMillis();
-			final DatabaseMetaData dbmd = conn.getMetaData();
+			//final DatabaseMetaData dbmd = conn.getMetaData();
 			// this behavior is slightly different from the jdbc call itself--
 			// the call allows schema to be null, in which case it doesn't filter on it.
 			// we assume the current schema for convenience & to limit results to one table
-			rs = dbmd.getIndexInfo("", getTk(m, "schema", conn.getSchema()), getTk(m, "table", null), false, false);
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 			final ResultSetMetaData meta = rs.getMetaData();
 
 			if (m.group("verbose") != null) {
@@ -911,7 +916,8 @@ public class CLI {
 
 		try {
 			start = System.currentTimeMillis();
-			rs = stmt.executeQuery(cmd);
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 
 			while (rs.next()) {
 				String planLine = rs.getString(1);
@@ -942,50 +948,26 @@ public class CLI {
 		ResultSet rs = null;
 		String plan = cmd.substring("PLAN EXECUTE ".length()).trim();
 
-		if (startsWithIgnoreCase(plan, "INLINE ")) {
-			plan = plan.substring("INLINE ".length()).trim();
+		try {
+			start = System.currentTimeMillis();
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
+			final ResultSetMetaData meta = rs.getMetaData();
 
+			printResultSet(rs, meta);
+			printWarnings(stmt);
+			printWarnings(rs);
+			end = System.currentTimeMillis();
+
+			rs.close();
+
+			printTime(start, end);
+		} catch (final Exception e) {
 			try {
-				start = System.currentTimeMillis();
-				rs = ((XGStatement) stmt).executeInlinePlan(plan);
-				final ResultSetMetaData meta = rs.getMetaData();
-
-				printResultSet(rs, meta);
-				printWarnings(stmt);
-				printWarnings(rs);
-				end = System.currentTimeMillis();
-
 				rs.close();
-
-				printTime(start, end);
-			} catch (final Exception e) {
-				try {
-					rs.close();
-				} catch (Exception f) {
-				}
-				System.out.println("Error: " + e.getMessage());
+			} catch (Exception f) {
 			}
-		} else {
-			try {
-				start = System.currentTimeMillis();
-				rs = ((XGStatement) stmt).executePlan(plan);
-				final ResultSetMetaData meta = rs.getMetaData();
-
-				printResultSet(rs, meta);
-				printWarnings(stmt);
-				printWarnings(rs);
-				end = System.currentTimeMillis();
-
-				rs.close();
-
-				printTime(start, end);
-			} catch (final Exception e) {
-				try {
-					rs.close();
-				} catch (Exception f) {
-				}
-				System.out.println("Error: " + e.getMessage());
-			}
+			System.out.println("Error: " + e.getMessage());
 		}
 	}
 
@@ -997,18 +979,18 @@ public class CLI {
 			return;
 		}
 
+		ResultSet rs = null;
 		try {
 			start = System.currentTimeMillis();
-			String plan = cmd.substring("PLAN EXPLAIN ".length()).trim();
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
 
-			ClientWireProtocol.ExplainFormat format = ClientWireProtocol.ExplainFormat.PROTO;
-			if (startsWithIgnoreCase(plan, "JSON ")) {
-				plan = plan.substring("JSON ".length()).trim();
-				format = ClientWireProtocol.ExplainFormat.JSON;
+			while (rs.next()) {
+				String planLine = rs.getString(1);
+				System.out.println(planLine);
 			}
-			final String pm = ((XGStatement) stmt).explainPlan(plan, format);
-
-			System.out.println(pm);
+			rs.close();
+			//System.out.println(pm);
 			
 			printWarnings(stmt);
 			end = System.currentTimeMillis();
@@ -1055,8 +1037,7 @@ public class CLI {
 		}
 		try {
 			start = System.currentTimeMillis();
-			final String uuid = cmd.substring("CANCEL ".length()).trim();
-			((XGStatement) stmt).cancelQuery(uuid);
+			stmt.execute(cmd);
 			printWarnings(stmt);
 			end = System.currentTimeMillis();
 
@@ -1075,8 +1056,7 @@ public class CLI {
 		}
 		try {
 			start = System.currentTimeMillis();
-			final int maxRows = Integer.parseInt(cmd.substring("SET MAXROWS ".length()).trim());
-			((XGStatement) stmt).setMaxRows(maxRows);
+			stmt.execute(cmd);
 		} catch (final Exception e) {
 			System.out.println("CLI Error: " + e.getMessage());
 		}
@@ -1109,8 +1089,7 @@ public class CLI {
 		}
 		try {
 			start = System.currentTimeMillis();
-			final String uuid = cmd.substring("KILL ".length()).trim();
-			((XGStatement) stmt).killQuery(uuid);
+			stmt.execute(cmd);
 			printWarnings(stmt);
 			end = System.currentTimeMillis();
 
@@ -1120,27 +1099,32 @@ public class CLI {
 		}
 	}
 
-	private static void listAllQueries() {
+	private static void listAllQueries(final String cmd) {
 		long start = 0;
 		long end = 0;
 		if (!isConnected()) {
 			System.out.println("No database connection exists");
 			return;
 		}
+		ResultSet rs = null;
 		try {
 			start = System.currentTimeMillis();
-			final ArrayList<SysQueriesRow> queryList = ((XGStatement) stmt).listAllQueries();
+			stmt.execute(cmd);
+			rs = stmt.getResultSet();
+			final ResultSetMetaData meta = rs.getMetaData();
+			printResultSet(rs, meta);
 
-			if (queryList.size() > 0) {
-				printAllQueries(queryList);
-			}
-
-			printWarnings(stmt);
+			printWarnings(rs);
 			end = System.currentTimeMillis();
 
 			printTime(start, end);
+			rs.close();
 		} catch (final Exception e) {
-			System.out.println("CLI Error: " + e.getMessage());
+			try{
+				rs.close();
+			} catch (Exception f){	
+			}
+			System.out.println("Error: " + e.getMessage());
 		}
 	}
 

--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -1832,7 +1832,7 @@ public class XGConnection implements Connection {
 		b2.setType(ClientWireProtocol.Request.RequestType.SET_SCHEMA);
 		b2.setSetSchema(msg);
 		final Request wrapper = b2.build();
-		LOGGER.log(Level.INFO,String.format("Made it here A"));
+
 		try {
 			out.write(intToBytes(wrapper.getSerializedSize()));
 			wrapper.writeTo(out);

--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -1065,6 +1065,7 @@ public class XGConnection implements Connection {
 		final ConfirmationResponse response = gsr.getResponse();
 		final ResponseType rType = response.getType();
 		processResponseType(rType, response);
+		LOGGER.log(Level.INFO, String.format("Got schema: %s from server", gsr.getSchema()));
 		return gsr.getSchema();
 	}
 
@@ -1823,7 +1824,7 @@ public class XGConnection implements Connection {
 
 	private void sendSetSchema(final String schema) throws Exception {
 		// send request
-		LOGGER.log(Level.INFO, "Sending set schema request to the server");
+		LOGGER.log(Level.INFO, String.format("Sending set schema (%s) request to the server", schema));
 		final ClientWireProtocol.SetSchema.Builder builder = ClientWireProtocol.SetSchema.newBuilder();
 		builder.setSchema(schema);
 		final SetSchema msg = builder.build();
@@ -1831,7 +1832,7 @@ public class XGConnection implements Connection {
 		b2.setType(ClientWireProtocol.Request.RequestType.SET_SCHEMA);
 		b2.setSetSchema(msg);
 		final Request wrapper = b2.build();
-
+		LOGGER.log(Level.INFO,String.format("Made it here A"));
 		try {
 			out.write(intToBytes(wrapper.getSerializedSize()));
 			wrapper.writeTo(out);

--- a/src/main/java/com/ocient/jdbc/XGResultSet.java
+++ b/src/main/java/com/ocient/jdbc/XGResultSet.java
@@ -2359,6 +2359,7 @@ public class XGResultSet implements ResultSet {
 	}
 
 	private void requestMetaData() throws Exception {
+		LOGGER.log(Level.INFO, "Called requestMetaData()");
 		stmt.passUpCancel(false);
 		try {
 			// send fetch metadata request

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -818,11 +818,11 @@ public class XGStatement implements Statement {
 		pos2Cols.put(8, "sql");
 
 		cols2Types.put("query_id", "CHAR");
-		cols2Types.put("user", "FLOAT");
-		cols2Types.put("importance", "INT");
-		cols2Types.put("estimated_time", "CHAR");
-		cols2Types.put("elapsed_time", "CHAR");
-		cols2Types.put("status", "INT");
+		cols2Types.put("user", "CHAR");
+		cols2Types.put("importance", "FLOAT");
+		cols2Types.put("estimated_time", "INT");
+		cols2Types.put("elapsed_time", "INT");
+		cols2Types.put("status", "CHAR");
 		cols2Types.put("server", "CHAR");
 		cols2Types.put("database", "CHAR");
 		cols2Types.put("sql", "CHAR");

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.Array;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -18,10 +19,15 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.OptionalLong;
 import java.util.logging.Logger;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import com.ocient.jdbc.proto.ClientWireProtocol;
 import com.ocient.jdbc.proto.ClientWireProtocol.CancelQuery;
 import com.ocient.jdbc.proto.ClientWireProtocol.ConfirmationResponse;
@@ -431,7 +437,11 @@ public class XGStatement implements Statement {
 
 		try {
 			passUpCancel(false);
-			if (sql.toUpperCase().startsWith("SELECT") || sql.toUpperCase().startsWith("WITH")) {
+			if (sql.toUpperCase().startsWith("SELECT") || sql.toUpperCase().startsWith("WITH") || sql.toUpperCase().startsWith("EXPLAIN") ||
+			sql.toUpperCase().startsWith("LIST TABLES") || sql.toUpperCase().startsWith("LIST SYSTEM TABLES") || sql.toUpperCase().startsWith("LIST VIEWS") || 
+			sql.toUpperCase().startsWith("LIST INDICES") || sql.toUpperCase().startsWith("LIST INDEXES") || sql.toUpperCase().startsWith("GET SCHEMA") || 
+			sql.toUpperCase().startsWith("DESCRIBE VIEW") || sql.toUpperCase().startsWith("DESCRIBE TABLE") || sql.toUpperCase().startsWith("PLAN EXECUTE") || 
+			sql.toUpperCase().startsWith("PLAN EXPLAIN") || sql.toUpperCase().startsWith("LIST ALL QUERIES") || sql.toUpperCase().startsWith("EXPORT TABLE")) {
 				this.result = (XGResultSet) executeQuery(sql);
 				return true;
 			} else {
@@ -485,45 +495,34 @@ public class XGStatement implements Statement {
 
 	@Override
 	public ResultSet executeQuery(String sql) throws SQLException {
-		LOGGER.log(Level.INFO, "Called executeQuery()");
-		String explain = "";
-		boolean isExplain = false;
+		LOGGER.log(Level.INFO, String.format("Called executeQuery() with sql : %s", sql));
 		sql = sql.trim();
-		if (startsWithIgnoreCase(sql, "EXPLAIN JSON")) {
-			final String sqlQuery = sql.substring("EXPLAIN JSON".length()).trim();
-			try {
-				// get the plan in proto format and convert it to its Json representation
-				LOGGER.log(Level.INFO, String.format("Doing a JSON explain of: %s", sqlQuery));
-				explain = explain(sqlQuery, ClientWireProtocol.ExplainFormat.JSON);
-			} catch (Exception e) {
-				throw SQLStates.newGenericException(e);
+		try{
+			if (startsWithIgnoreCase(sql, "EXPLAIN")) {
+				return explain(sql);
+			} else if (startsWithIgnoreCase(sql, "LIST TABLES") || startsWithIgnoreCase(sql, "LIST SYSTEM TABLES")){
+				return listTables(sql, startsWithIgnoreCase(sql, "LIST SYSTEM TABLES"));
+			} else if (startsWithIgnoreCase(sql, "LIST VIEWS")){
+				return listViews(sql);
+			} else if (startsWithIgnoreCase(sql, "LIST INDICES") || startsWithIgnoreCase(sql, "LIST INDEXES")){
+				return listIndexes(sql);
+			} else if (startsWithIgnoreCase(sql, "GET SCHEMA")){
+				return getSchema();
+			} else if(startsWithIgnoreCase(sql, "DESCRIBE TABLE")){
+				return describeTable(sql);
+			} else if(startsWithIgnoreCase(sql, "DESCRIBE VIEW")){
+				return describeView(sql);
+			} else if(startsWithIgnoreCase(sql, "PLAN EXECUTE")){
+				return executePlanSQL(sql);
+			} else if(startsWithIgnoreCase(sql, "PLAN EXPLAIN")){
+				return explainPlanSQL(sql);
+			} else if(startsWithIgnoreCase(sql, "LIST ALL QUERIES")){
+				return listAllQueries();
+			} else if(startsWithIgnoreCase(sql, "EXPORT TABLE")){
+				return exportTableSQL(sql);
 			}
-			isExplain = true;
-		} else if (startsWithIgnoreCase(sql, "EXPLAIN")) {
-			final String sqlQuery = sql.substring("EXPLAIN ".length()).trim();
-
-			LOGGER.log(Level.INFO, String.format("Doing an explain of: %s", sqlQuery));
-			// get the plan in proto format and convert it to its google proto buffer string
-			// representation
-			explain = explain(sqlQuery, ClientWireProtocol.ExplainFormat.PROTO);
-			isExplain = true;
-		}
-
-		if (isExplain) {
-			// split the proto string using the line break delimiter and build an one string
-			// column resultset.
-			ArrayList<Object> rs = new ArrayList<>();
-			String lines[] = explain.split("\\r?\\n");
-
-			for (int i = 0; i < lines.length; i++) {
-				String str = lines[i];
-				ArrayList<Object> row = new ArrayList<>();
-				row.add(str);
-				rs.add(row);
-			}
-			result = conn.rs = new XGResultSet(conn, rs, this);
-			this.updateCount = -1;
-			return result;
+		} catch (Exception e) {
+			throw SQLStates.newGenericException(e);
 		}
 
 		// Handle maxRows
@@ -558,7 +557,7 @@ public class XGStatement implements Statement {
 
 	@Override
 	public int executeUpdate(String sql) throws SQLException {
-		LOGGER.log(Level.INFO, "Called executeUpdate()");
+		LOGGER.log(Level.INFO, String.format("Called executeUpdate() with sql: %s", sql));
 		// if this is a set command we just use a separately crafted proto message to
 		// make things simpler
 		sql = sql.trim();
@@ -594,6 +593,12 @@ public class XGStatement implements Statement {
 			}
 
 			return 0;
+		} else if(sql.toUpperCase().startsWith("KILL") || sql.toUpperCase().startsWith("CANCEL")){
+			return killCancelQuery(sql);
+		} else if (sql.toUpperCase().startsWith("SET MAXROWS")){
+			return setMaxRowsSQL(sql);
+		} else if(sql.toUpperCase().startsWith("SET SCHEMA")){
+			return setSchema(sql);
 		}
 
 		// otherwise we are handling a normal update command
@@ -654,24 +659,56 @@ public class XGStatement implements Statement {
 		return planProtoToString(er.getPlan(), format);
 	}
 
-	// used by CLI
-	public String explain(final String sql, final ClientWireProtocol.ExplainFormat format) throws SQLException {
+	private ResultSet explain(final String cmd) throws SQLException {
+		LOGGER.log(Level.INFO, "Entered Driver's explain()");
 
+		ClientWireProtocol.ExplainFormat format;
+		String explainString;
+		String sql = "";
+
+		if(startsWithIgnoreCase(cmd, "EXPLAIN JSON")){
+			format = ClientWireProtocol.ExplainFormat.JSON;
+			sql = cmd.substring("EXPLAIN JSON".length()).trim();
+		} else {
+			format = ClientWireProtocol.ExplainFormat.PROTO;
+			sql = cmd.substring("EXPLAIN".length()).trim();
+		}
 		if(shouldDeprecatedExplain())
 		{
-			return explainDeprecated(sql, format);
+			explainString = explainDeprecated(sql, format);
+		} else {
+			Function<Object, Void> typeSetter = (Object builder) -> {
+				ClientWireProtocol.ExecuteExplain.Builder typedBuilder = (ClientWireProtocol.ExecuteExplain.Builder) builder;
+				typedBuilder.setFormat(format);
+				return null;
+			};
+
+			final ClientWireProtocol.ExplainResponseStringPlan.Builder er = (ClientWireProtocol.ExplainResponseStringPlan.Builder) sendAndReceive(
+					sql, Request.RequestType.EXECUTE_EXPLAIN, 0, false, Optional.of(typeSetter));
+			explainString = er.getPlan();
 		}
 
+		ArrayList<Object> rs = new ArrayList<>();
+		String lines[] = explainString.split("\\r?\\n");
+		for (int i = 0; i < lines.length; i++) {
+			String str = lines[i];
+			ArrayList<Object> row = new ArrayList<>();
+			row.add(str);
+			rs.add(row);
+		}
 
-		Function<Object, Void> typeSetter = (Object builder) -> {
-			ClientWireProtocol.ExecuteExplain.Builder typedBuilder = (ClientWireProtocol.ExecuteExplain.Builder) builder;
-			typedBuilder.setFormat(format);
-			return null;
-		};
+		result = conn.rs = new XGResultSet(conn, rs, this);
+		Map<String, Integer> cols2Pos = new HashMap<String, Integer>();
+		TreeMap<Integer, String> pos2Cols = new TreeMap<Integer, String>();
+		Map<String, String> cols2Types = new HashMap<String, String>();
+		cols2Pos.put("explain", 0);
+		pos2Cols.put(0, "explain");
+		cols2Types.put("explain", "CHAR");
+		result.setCols2Pos(cols2Pos);
+		result.setPos2Cols(pos2Cols);
+		result.setCols2Types(cols2Types);
 
-		final ClientWireProtocol.ExplainResponseStringPlan.Builder er = (ClientWireProtocol.ExplainResponseStringPlan.Builder) sendAndReceive(
-				sql, Request.RequestType.EXECUTE_EXPLAIN, 0, false, Optional.of(typeSetter));
-		return er.getPlan();
+		return result;
 	}
 
 	//Used before version 7.0.1
@@ -702,8 +739,8 @@ public class XGStatement implements Statement {
 		return er.getPlan();
 	}
 
-	// used by CLI
 	public ResultSet executePlan(final String plan) throws SQLException {
+		LOGGER.log(Level.INFO, "executePlan()");
 		sendAndReceive(plan, Request.RequestType.EXECUTE_PLAN, 0, false, Optional.empty());
 		try {
 			result = conn.rs = new XGResultSet(conn, fetchSize, this);
@@ -723,8 +760,8 @@ public class XGStatement implements Statement {
 		return result;
 	}
 
-	// used by CLI
 	public ResultSet executeInlinePlan(final String plan) throws SQLException {
+		LOGGER.log(Level.INFO, "executeInlinePlan()");
 		sendAndReceive(plan, Request.RequestType.EXECUTE_INLINE_PLAN, 0, false, Optional.empty());
 		try {
 			result = conn.rs = new XGResultSet(conn, fetchSize, this);
@@ -768,17 +805,67 @@ public class XGStatement implements Statement {
 		return;
 	}
 
-	// used by CLI
-	public ArrayList<SysQueriesRow> listAllQueries() throws SQLException {
+	private ResultSet listAllQueries() throws SQLException {
 		final ClientWireProtocol.SystemWideQueriesResponse.Builder er = (ClientWireProtocol.SystemWideQueriesResponse.Builder) sendAndReceive(
 				"", Request.RequestType.SYSTEM_WIDE_QUERIES, 0, false, Optional.empty());
 
-		ArrayList<SysQueriesRow> queries = new ArrayList<SysQueriesRow>(er.getRowsCount());
-		for (int i = 0; i < er.getRowsCount(); ++i) {
-			queries.add(er.getRows(i));
+		// Manufacture the result set.
+		ArrayList<Object> rs = new ArrayList<>(er.getRowsCount());
+		for(int i = 0; i < er.getRowsCount(); i++){
+			SysQueriesRow row = er.getRows(i);
+			ArrayList<Object> newRow = new ArrayList<>();
+			newRow.add(row.getQueryId());
+			newRow.add(row.getUserid());
+			newRow.add(row.getImportance());
+			newRow.add(row.getEstimatedTimeSec());
+			newRow.add(row.getElapsedTimeSec());
+			newRow.add(row.getStatus());
+			newRow.add(row.getQueryServer());
+			newRow.add(row.getDatabase());
+			newRow.add(row.getSqlText());
+			rs.add(newRow);
 		}
+		result = conn.rs = new XGResultSet(conn, rs, this);
+		// Map the table metadata
+		Map<String, Integer> cols2Pos = new HashMap<String, Integer>();
+		TreeMap<Integer, String> pos2Cols = new TreeMap<Integer, String>();
+		Map<String, String> cols2Types = new HashMap<String, String>();
+		cols2Pos.put("query_id", 0);
+		cols2Pos.put("user", 1);
+		cols2Pos.put("importance", 2);
+		cols2Pos.put("estimated_time", 3);
+		cols2Pos.put("elapsed_time", 4);
+		cols2Pos.put("status", 5);
+		cols2Pos.put("server", 6);
+		cols2Pos.put("database", 7);
+		cols2Pos.put("sql", 8);
 
-		return queries;
+		pos2Cols.put(0, "query_id");
+		pos2Cols.put(1, "user");
+		pos2Cols.put(2, "importance");
+		pos2Cols.put(3, "estimated_time");
+		pos2Cols.put(4, "elapsed_time");
+		pos2Cols.put(5, "status");
+		pos2Cols.put(6, "server");
+		pos2Cols.put(7, "database");
+		pos2Cols.put(8, "sql");
+
+		cols2Types.put("query_id", "CHAR");
+		cols2Types.put("user", "FLOAT");
+		cols2Types.put("importance", "INT");
+		cols2Types.put("estimated_time", "CHAR");
+		cols2Types.put("elapsed_time", "CHAR");
+		cols2Types.put("status", "INT");
+		cols2Types.put("server", "CHAR");
+		cols2Types.put("database", "CHAR");
+		cols2Types.put("sql", "CHAR");
+
+		result.setCols2Pos(cols2Pos);
+		result.setPos2Cols(pos2Cols);
+		result.setCols2Types(cols2Types);
+
+		this.updateCount = -1;
+		return result;
 	}
 
 	// used by CLI
@@ -1571,4 +1658,272 @@ public class XGStatement implements Statement {
 		LOGGER.log(Level.WARNING, "unwrap() was called, which is not supported");
 		throw new SQLFeatureNotSupportedException();
 	}
+	/*!
+	 * New functions which have been moved from the CLI into the driver.
+	 * TODO: move some of these utility functions into another file to clean this up a bit.
+	 */
+
+	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
+	// (.) token. Reluctant.
+	// Do not insert multiple regexes for tokens of the same name (or "q0" + another
+	// name) into a single pattern.
+	private static String tk(String name) {
+		return "(?<q0" + name + ">\"?)(?<" + name + ">(\\w+?|(?<=\").+?(?=\")))\\k<q0" + name + ">";
+	}
+
+	// Get a token from its generated regex according to SQL case-sensitivity rules
+	// (sensitive iff quoted).
+	// Do not call on a matcher that has not yet called matches().
+	private static String getTk(Matcher m, String name, String def) {
+		if (m.group(name) == null) {
+			return def;
+		}
+		if (m.group("q0" + name).length() == 0) {
+			return m.group(name).toLowerCase();
+		}
+		return m.group(name);
+	}
+
+	private static Pattern listTablesSyntax = Pattern.compile("list\\s+tables(?<verbose>\\s+verbose)?",
+			Pattern.CASE_INSENSITIVE);
+
+	private static Pattern listSystemTablesSyntax = Pattern.compile("list\\s+system\\s+tables(?<verbose>\\s+verbose)?",
+			Pattern.CASE_INSENSITIVE);
+
+	private ResultSet listTables(final String cmd, boolean isSystemTables) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's listTables()");
+		ResultSet rs = null;
+
+		final Matcher m = isSystemTables ? listSystemTablesSyntax.matcher(cmd) : listTablesSyntax.matcher(cmd);
+		if (!m.matches()) {
+			// this line will never be reached,
+			// but we have to call matches() anyway
+			LOGGER.log(Level.WARNING, "Driver's listTables() reached a line it shouldn't have.");
+			return rs;
+		}
+		final DatabaseMetaData dbmd = conn.getMetaData();
+		if (isSystemTables) {
+			final XGDatabaseMetaData xgdbmd = (XGDatabaseMetaData) dbmd;
+			rs = xgdbmd.getSystemTables("", "%", "%", new String[0]);
+		} else {
+			rs = dbmd.getTables("", "%", "%", new String[0]);
+		}
+		return rs;
+	}
+
+	private static Pattern listViewsSyntax = Pattern.compile("list\\s+views(?<verbose>\\s+verbose)?",
+			Pattern.CASE_INSENSITIVE);
+
+	private ResultSet listViews(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's listViews()");
+		ResultSet rs = null;
+
+		final Matcher m = listViewsSyntax.matcher(cmd);
+		if (!m.matches()) {
+			// this line will never be reached,
+			// but we have to call matches() anyway
+			LOGGER.log(Level.WARNING, "Driver's listViews() reached a line it shouldn't have.");
+			return rs;
+		}
+		final DatabaseMetaData md = conn.getMetaData();
+		final XGDatabaseMetaData dbmd = (XGDatabaseMetaData) md;
+
+		return dbmd.getViews("", "%", "%", new String[0]);
+	}
+
+	private static Pattern listIndexesSyntax = Pattern.compile(
+			"list\\s+ind(ic|ex)es\\s+((" + tk("schema") + ")\\.)?(" + tk("table") + ")(?<verbose>\\s+verbose)?",
+			Pattern.CASE_INSENSITIVE);
+
+	private ResultSet listIndexes(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's listIndexes()");
+		ResultSet rs = null;
+		final Matcher m = listIndexesSyntax.matcher(cmd);
+	
+		if (!m.matches()) {
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify(
+					"Syntax: list indexes (<schema>.)?<table>");
+		}
+		final DatabaseMetaData dbmd = conn.getMetaData();
+		return dbmd.getIndexInfo("", getTk(m, "schema", conn.getSchema()), getTk(m, "table", null), false, false);
+	}
+
+	private ResultSet getSchema() throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's getSchema()");
+		String schema = conn.getSchema();
+		// Construct the result set.
+		// split the proto string using the line break delimiter and build a one string
+		// column resultset.
+		ArrayList<Object> rs = new ArrayList<>();
+		String lines[] = schema.split("\\r?\\n");
+		for (int i = 0; i < lines.length; i++) {
+			String str = lines[i];
+			ArrayList<Object> row = new ArrayList<>();
+			row.add(str);
+			rs.add(row);
+		}
+		System.out.println("A");
+		System.out.println("B");
+		result = conn.rs = new XGResultSet(conn, rs, this);
+
+		Map<String, Integer> cols2Pos = new HashMap<String, Integer>();
+		TreeMap<Integer, String> pos2Cols = new TreeMap<Integer, String>();
+		Map<String, String> cols2Types = new HashMap<String, String>();
+		cols2Pos.put("schema", 0);
+		pos2Cols.put(0, "schema");
+		cols2Types.put("schema", "CHAR");
+		result.setCols2Pos(cols2Pos);
+		result.setPos2Cols(pos2Cols);
+		result.setCols2Types(cols2Types);
+
+		return result;
+	}
+
+	private static Pattern describeTableSyntax = Pattern.compile(
+			"describe(\\s+table\\s+)?((" + tk("schema") + ")\\.)?(" + tk("table") + ")(?<verbose>\\s+verbose)?",
+			Pattern.CASE_INSENSITIVE);
+
+	private ResultSet describeTable(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's describeTable()");
+		ResultSet rs = null;
+		final Matcher m = describeTableSyntax.matcher(cmd);
+		if (!m.matches()) {
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify(
+					"Syntax: describe (<schema>.)?<table>");
+		}
+		final DatabaseMetaData dbmd = conn.getMetaData();
+		return dbmd.getColumns("", getTk(m, "schema", conn.getSchema()), getTk(m, "table", null), "%");
+	}
+
+	private static Pattern describeViewSyntax = Pattern.compile(
+		"describe(\\s+view\\s+)?((" + tk("schema") + ")\\.)?(" + tk("view") + ")(?<verbose>\\s+verbose)?",
+		Pattern.CASE_INSENSITIVE);
+
+	private ResultSet describeView(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's describeView()");
+		ResultSet rs = null;
+		final Matcher m = describeViewSyntax.matcher(cmd);
+		if (!m.matches()) {
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify(
+					"Syntax: describe view (<schema>.)?<view>");
+		}
+		final DatabaseMetaData md = conn.getMetaData();
+		final XGDatabaseMetaData dbmd = (XGDatabaseMetaData) md;
+		return dbmd.getViews("", getTk(m, "schema", conn.getSchema()), getTk(m, "view", null), null);
+	}
+
+	private ResultSet executePlanSQL(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's executePlan()");
+		ResultSet rs = null;
+		String plan = cmd.substring("PLAN EXECUTE ".length()).trim();
+
+		if(startsWithIgnoreCase(plan, "INLINE ")){
+			plan = plan.substring("INLINE ".length()).trim();
+			rs = executeInlinePlan(plan);
+		} else {
+			rs = executePlan(plan);
+		}
+		return rs;
+	}
+
+	private ResultSet explainPlanSQL(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Entered driver's explainPlan()");
+		String plan = cmd.substring("PLAN EXPLAIN ".length()).trim();
+		ClientWireProtocol.ExplainFormat format = ClientWireProtocol.ExplainFormat.PROTO;
+		if (startsWithIgnoreCase(plan, "JSON ")) {
+			plan = plan.substring("JSON ".length()).trim();
+			format = ClientWireProtocol.ExplainFormat.JSON;
+		}
+		String pm = explainPlan(plan, format);
+		ArrayList<Object> rs = new ArrayList<>();
+		String lines[] = pm.split("\\r?\\n");
+		for (int i = 0; i < lines.length; i++) {
+			String str = lines[i];
+			ArrayList<Object> row = new ArrayList<>();
+			row.add(str);
+			rs.add(row);
+		}
+
+		result = conn.rs = new XGResultSet(conn, rs, this);
+		Map<String, Integer> cols2Pos = new HashMap<String, Integer>();
+		TreeMap<Integer, String> pos2Cols = new TreeMap<Integer, String>();
+		Map<String, String> cols2Types = new HashMap<String, String>();
+		cols2Pos.put("explain", 0);
+		pos2Cols.put(0, "explain");
+		cols2Types.put("explain", "CHAR");
+		result.setCols2Pos(cols2Pos);
+		result.setPos2Cols(pos2Cols);
+		result.setCols2Types(cols2Types);
+
+		return result;
+	}
+
+	private ResultSet exportTableSQL(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO, "Enetered driver's exportTable");
+		String exportStr = exportTable(cmd);
+		ArrayList<Object> rs = new ArrayList<>();
+		String lines[] = exportStr.split("\\r?\\n");
+		for (int i = 0; i < lines.length; i++) {
+			String str = lines[i];
+			ArrayList<Object> row = new ArrayList<>();
+			row.add(str);
+			rs.add(row);
+		}
+	
+		result = conn.rs = new XGResultSet(conn, rs, this);
+		Map<String, Integer> cols2Pos = new HashMap<String, Integer>();
+		TreeMap<Integer, String> pos2Cols = new TreeMap<Integer, String>();
+		Map<String, String> cols2Types = new HashMap<String, String>();
+		cols2Pos.put("export", 0);
+		pos2Cols.put(0, "export");
+		cols2Types.put("export", "CHAR");
+		result.setCols2Pos(cols2Pos);
+		result.setPos2Cols(pos2Cols);
+		result.setCols2Types(cols2Types);
+
+		return result;
+	}
+
+	/*!
+	 * Non result set custom functions.
+	 * The int values returned by these functions will indicate the number of modifed rows.
+	 */
+
+	private int killCancelQuery(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO,"Entered driver's killCancelQuery()");
+		String uuid;
+		if (startsWithIgnoreCase(cmd, "KILL ")) {
+			uuid = cmd.substring("KILL ".length()).trim();
+			killQuery(uuid);
+		} else {
+			// Cancel
+			uuid = cmd.substring("CANCEL ".length()).trim();
+			cancelQuery(uuid);
+		}
+		return 0;
+
+	}
+
+	private int setMaxRowsSQL(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO,"Entered driver's setMaxRows()");
+		final int maxRow = Integer.parseInt(cmd.substring("SET MAXROWS ".length()).trim());
+		setMaxRows(maxRow);
+		return 0;
+	}
+
+	private int setSchema(final String cmd) throws SQLException{
+		LOGGER.log(Level.INFO,"Entered driver's setSchema()");
+		String schema = cmd.substring(11).trim();
+		if (schema.startsWith("\"")) {
+			if (!schema.endsWith("\"")) {
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify(
+					"Uncloseed Quotes!");
+			}
+
+			schema = schema.substring(1, schema.length() - 1);
+		}
+		conn.setSchema(schema);
+		return 0;
+	}
+
 }

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -1762,8 +1762,6 @@ public class XGStatement implements Statement {
 			row.add(str);
 			rs.add(row);
 		}
-		System.out.println("A");
-		System.out.println("B");
 		result = conn.rs = new XGResultSet(conn, rs, this);
 
 		Map<String, Integer> cols2Pos = new HashMap<String, Integer>();

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,14 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 // tag::compact[]
+== 1.40 (2020-08-14)
+
+New Features::
+
+  * Move some custom functionalities into the driver including: get/set schema, list (system) tables, list views, describe table/views, list indexes, 
+    execute/explain plan, cancel/kill query, list all queries, export table, set max rows, set pso.
+
+// tag::compact[]
 == 1.41 (2020-08-20)
 
 New Features::

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,7 +5,7 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 // tag::compact[]
-== 1.40 (2020-08-14)
+== 1.42 (2020-08-14)
 
 New Features::
 


### PR DESCRIPTION

https://jira.ocient.com:8443/browse/DB-11653

Move the following functions into the driver:

1. setSchema / getSchema 
2. listTables 
3. List system tables
4. listViews 
5. describeTable
6. describeView 
7. listIndexes
8. executePlan / explainPlan
9. cancel / kill query
10. listAllQueries 
11. exportTable
12. Set maxrows 
13. Set pso check (Was already there)

Now we can run these on Dbeaver and they will return a result set.

![Screen Shot 2020-09-01 at 5 25 06 PM](https://user-images.githubusercontent.com/65177031/91912126-1c1b4000-ec78-11ea-8e0b-0730f6e48c53.png)