### PR TITLE
[DB-12812] fix illegalargument when logfile is changed

### DIFF
--- a/src/main/java/com/ocient/jdbc/JDBCDriver.java
+++ b/src/main/java/com/ocient/jdbc/JDBCDriver.java
@@ -281,12 +281,12 @@ public class JDBCDriver implements Driver
 		{
 			String loglevel = props.getProperty("loglevel");
 			String logfile = props.getProperty("logfile");
-			if (loglevel == null || logfile == null || logfile.equals(""))
+			if (loglevel == null || logfile == null)
 			{
 				LOGGER.setLevel(Level.OFF);
 				return;
 			}
-			LOGGER.log(Level.INFO, String.format("New logger settigs. LogLevel: %s. LogFile: %s",loglevel, logfile));
+			LOGGER.log(Level.INFO, String.format("New logger settings. LogLevel: %s. LogFile: %s",loglevel, logfile));
 			
 			if (loglevel != null) {
 				if (loglevel.equalsIgnoreCase("OFF")) {
@@ -296,11 +296,7 @@ public class JDBCDriver implements Driver
 					LOGGER.setLevel(Level.ALL);
 				} else if (loglevel.equalsIgnoreCase("ERROR")) {
 					LOGGER.setLevel(Level.WARNING);
-				} else {
-					// Invalid argument.
-					LOGGER.setLevel(Level.OFF);
-					return;
-				}
+				} 
 			}
 	
 			/* If logfile hasn't changed, return */

--- a/src/main/java/com/ocient/jdbc/JDBCDriver.java
+++ b/src/main/java/com/ocient/jdbc/JDBCDriver.java
@@ -296,7 +296,7 @@ public class JDBCDriver implements Driver
 					LOGGER.setLevel(Level.ALL);
 				} else if (loglevel.equalsIgnoreCase("ERROR")) {
 					LOGGER.setLevel(Level.WARNING);
-				} 
+				}
 			}
 	
 			/* If logfile hasn't changed, return */

--- a/src/main/java/com/ocient/jdbc/JDBCDriver.java
+++ b/src/main/java/com/ocient/jdbc/JDBCDriver.java
@@ -281,11 +281,12 @@ public class JDBCDriver implements Driver
 		{
 			String loglevel = props.getProperty("loglevel");
 			String logfile = props.getProperty("logfile");
-			if (loglevel == null || logfile == null)
+			if (loglevel == null || logfile == null || logfile.equals(""))
 			{
 				LOGGER.setLevel(Level.OFF);
 				return;
 			}
+			LOGGER.log(Level.INFO, String.format("New logger settigs. LogLevel: %s. LogFile: %s",loglevel, logfile));
 			
 			if (loglevel != null) {
 				if (loglevel.equalsIgnoreCase("OFF")) {
@@ -295,6 +296,10 @@ public class JDBCDriver implements Driver
 					LOGGER.setLevel(Level.ALL);
 				} else if (loglevel.equalsIgnoreCase("ERROR")) {
 					LOGGER.setLevel(Level.WARNING);
+				} else {
+					// Invalid argument.
+					LOGGER.setLevel(Level.OFF);
+					return;
 				}
 			}
 	
@@ -317,8 +322,11 @@ public class JDBCDriver implements Driver
 				logFileName = logfile;
 				LOGGER.addHandler(logHandler);
 				LOGGER.log(Level.INFO, "Enabling logger");
-			} catch (final IOException e) {
+			} catch (final IOException | IllegalArgumentException e) {
 				e.printStackTrace(System.err);
+				// An illegal file argument was entered most likely.
+				LOGGER.setLevel(Level.OFF);
+				return;
 			}
 		}
 	}


### PR DESCRIPTION
https://jira.ocient.com:8443/browse/DB-12812

When you change the logfile from a value to a non value, an emptry  string is entered. This gets pass all our checks until it lands in FileHandler("",true) which throws IllegalArgumentException.

