### PR TITLE
Get rid of a log

### DIFF
--- a/src/main/java/com/ocient/jdbc/JDBCDriver.java
+++ b/src/main/java/com/ocient/jdbc/JDBCDriver.java
@@ -286,7 +286,6 @@ public class JDBCDriver implements Driver
 				LOGGER.setLevel(Level.OFF);
 				return;
 			}
-			LOGGER.log(Level.INFO, String.format("New logger settings. LogLevel: %s. LogFile: %s",loglevel, logfile));
 			
 			if (loglevel != null) {
 				if (loglevel.equalsIgnoreCase("OFF")) {


### PR DESCRIPTION
Thought this would be helpful but it has side effects. When there was no logger set beforehand (i.e when its brought up for the first time), the log is getting printed out. This makes it appear in other debugging logs.