### PR TITLE
[DB-13317] executeQuery will not retry after reconnect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ocient</groupId>
 	<artifactId>ocient-jdbc4</artifactId>
-	<version>1.51</version> <!--JDBC VERSION NUMBER HERE -->
+	<version>1.52</version> <!--JDBC VERSION NUMBER HERE -->
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>JDBC Driver for connecting to an Ocient Database</description>
 	<url>http://www.ocient.com</url>

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -573,8 +573,9 @@ public class XGStatement implements Statement {
 				}
 				throw SQLStates.newGenericException(reconnectException);
 			}
-
-			return executeQuery(sql);
+			LOGGER.log(Level.WARNING,
+				String.format("Execute query resulted in an error. Reconnected but not rerunning query"));
+			throw SQLStates.NETWORK_COMMS_ERROR.cloneAndSpecify("Execute query resulted in an error. Reconnected but not rerunning query");
 		}
 		this.updateCount = -1;
 		return result;

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,13 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 // tag::compact[]
+== 1.52 (2020-10-19)
+
+New Features::
+
+ * executeQuery will not rerun query after reconnect.
+
+// tag::compact[]
 == 1.51 (2020-10-11)
 
 New Features::


### PR DESCRIPTION
https://jira.ocient.com:8443/browse/DB-13317

I simulate the situation by adding an assert(false) inside of cmdCompServer.cpp::"Command: RSMETA"

Before
![before](https://user-images.githubusercontent.com/65177031/96499705-61d59d00-1213-11eb-8cfc-b49a667f9180.png)
after
![after](https://user-images.githubusercontent.com/65177031/96499723-68fcab00-1213-11eb-8e18-67b2ee32503d.png)
 Will now only kill one sql node.
