### PR TITLE
fix another spot where all sql nodes can be brought down

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ocient</groupId>
 	<artifactId>ocient-jdbc4</artifactId>
-	<version>1.53</version> <!--JDBC VERSION NUMBER HERE -->
+	<version>1.54</version> <!--JDBC VERSION NUMBER HERE -->
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>JDBC Driver for connecting to an Ocient Database</description>
 	<url>http://www.ocient.com</url>

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -1441,7 +1441,7 @@ public class XGStatement implements Statement {
 				}
 				passUpCancel(false);
 				reconnect(); // try this at most once--if every node is down, report failure
-				return sendAndReceive(sql, requestType, val, isInMb, additionalPropertySetter);
+				throw SQLStates.NETWORK_COMMS_ERROR.cloneAndSpecify("Execute query resulted in an error. Reconnected but not rerunning query");
 			}
 		} catch (final Exception e) {
 			if (e instanceof SQLException) {

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,13 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 // tag::compact[]
+== 1.54 (2020-10-21)
+
+New Features::
+
+ * fix another spot where all the slq nodes can be brought down.
+
+// tag::compact[]
 == 1.53 (2020-10-20)
 
 New Features::


### PR DESCRIPTION
In debugging another ticket, I found another place where all the sql nodes can be brought down.
Now we should have 3 spots covered.
1. When the driver is waiting for the optimization
2. When the driver is waiting for the result set metadta
3. When the driver is fetching rows

