### PR TITLE
db 13452 fix fetch version redirect loop.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ocient</groupId>
 	<artifactId>ocient-jdbc4</artifactId>
-	<version>1.57</version> <!--JDBC VERSION NUMBER HERE -->
+	<version>1.58</version> <!--JDBC VERSION NUMBER HERE -->
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>JDBC Driver for connecting to an Ocient Database</description>
 	<url>http://www.ocient.com</url>

--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -720,7 +720,7 @@ public class XGConnection implements Connection {
 				LOGGER.log(Level.INFO, "Redirect command in ClientConnection2Response from server");
 				final String host = ccr2.getRedirectHost();
 				final int port = ccr2.getRedirectPort();
-				redirect(host, port);
+				redirect(host, port, shouldRequestVersion);
 			} 
 		} catch (final Exception e) {
 			LOGGER.log(Level.WARNING,
@@ -1361,7 +1361,7 @@ public class XGConnection implements Connection {
 
 		// We solve this by delaying slightly, which will slow the rate
 		// of stack growth enough that we will be ok
-		LOGGER.log(Level.INFO, "Enterred reconnect()");
+		LOGGER.log(Level.INFO, String.format("Enterred reconnect() with shouldRequestVersion: %b", shouldRequestVersion));
 		try {
 			Thread.sleep(250);
 		} catch (final InterruptedException e) {
@@ -1624,7 +1624,7 @@ public class XGConnection implements Connection {
 	/*
 	 * We have to told to redirect our request elsewhere.
 	 */
-	public void redirect(final String host, final int port) throws IOException, SQLException {
+	public void redirect(final String host, final int port, boolean shouldRequestVersion) throws IOException, SQLException {
 		LOGGER.log(Level.INFO,String.format("redirect(). Getting redirected to host: %s and port: %d", host, port));
 		oneShotForce = true;
 
@@ -1705,7 +1705,7 @@ public class XGConnection implements Connection {
 			}
 	
 			try {
-				clientHandshake(user, pwd, database, true);
+				clientHandshake(user, pwd, database, shouldRequestVersion);
 				oneShotForce = true;
 				if (!setSchema.equals("")) {
 					setSchema(setSchema);
@@ -1757,7 +1757,7 @@ public class XGConnection implements Connection {
 				}
 		
 				try {
-					clientHandshake(user, pwd, database, true);
+					clientHandshake(user, pwd, database, shouldRequestVersion);
 					oneShotForce = true;
 					if (!setSchema.equals("")) {
 						setSchema(setSchema);

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -1270,8 +1270,8 @@ public class XGStatement implements Statement {
 		return;
 	}
 
-	private void redirect(final String host, final int port) throws IOException, SQLException {
-		conn.redirect(host, port);
+	private void redirect(final String host, final int port, boolean shouldRequestVersion) throws IOException, SQLException {
+		conn.redirect(host, port, shouldRequestVersion);
 		oneShotForce = true;
 		conn.clearOneShotForce();
 		return;
@@ -1423,7 +1423,7 @@ public class XGStatement implements Statement {
 					if ((boolean) getRedirect.invoke(br)) {
 						final Method getRedirectHost = br.getClass().getMethod("getRedirectHost");
 						final Method getRedirectPort = br.getClass().getMethod("getRedirectPort");
-						redirect((String) getRedirectHost.invoke(br), (int) getRedirectPort.invoke(br));
+						redirect((String) getRedirectHost.invoke(br), (int) getRedirectPort.invoke(br), false);
 						return sendAndReceive(sql, requestType, val, isInMb, additionalPropertySetter);
 					}
 				}

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,13 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 // tag::compact[]
+== 1.58 (2020-11-4)
+
+New Features::
+
+ * fix fetch version redirect loop.
+
+// tag::compact[]
 == 1.57 (2020-11-4)
 
 New Features::


### PR DESCRIPTION
https://jira.ocient.com:8443/browse/DB-13452

Here was the problem.
1. first connection connects to node A and the is redirected to node B. calls fetch version.
2. fetch version spawns another statement which connects to node A as well. shouldFetchVersion = false
3. second statement is redirected to node B. Second connection connects to node B, but shouldFetchVerion is hard coded true.
4. second statement spawns another statement to fetchVersion.
and repeat...

This is why force=true, which stops redirections fixes it.
This has been broken for a while now. It just never took too much longer to connect because eventually the load balancing on the server stops redirecting us. Whatever was happening on canal, the logs indicated that there were 170 redirections before it finally gave up and did not redirect. I don't know how load balancing works exactly, but there must have been some activity on the first node.