### PR TITLE
Extract query id from EXECUTE_PLAN and EXECUTE_INLINE_PLAN responses

### DIFF
--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -1471,12 +1471,14 @@ public class XGStatement implements Statement {
           b1 = ExecutePlan.newBuilder();
           br = ClientWireProtocol.ExecuteQueryResponse.newBuilder();
           setWrapped = b2.getClass().getMethod("setExecutePlan", c);
+          hasQueryId = true;
           break;
         case EXECUTE_INLINE_PLAN:
           c = ExecuteInlinePlan.class;
           b1 = ExecuteInlinePlan.newBuilder();
           br = ClientWireProtocol.ExecuteQueryResponse.newBuilder();
           setWrapped = b2.getClass().getMethod("setExecuteInlinePlan", c);
+          hasQueryId = true;
           break;
         case EXPLAIN_PLAN:
           c = ExplainPlan.class;


### PR DESCRIPTION
Storing the query id allows the client to cancel/kill queries