### PR TITLE
[DB-17148] and [DB-17113] fix timeoutMillis and clear warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ocient</groupId>
   <artifactId>ocient-jdbc4</artifactId>
-  <version>2.13</version>
+  <version>2.14</version>
   <!--JDBC VERSION NUMBER HERE -->
   <name>${project.groupId}:${project.artifactId}</name>
   <description>JDBC Driver for connecting to an Ocient Database</description>

--- a/src/main/java/com/ocient/jdbc/XGConnection.java
+++ b/src/main/java/com/ocient/jdbc/XGConnection.java
@@ -322,6 +322,8 @@ public class XGConnection implements Connection
 	public XGConnection(final String user, final String pwd, final int portNum, final String url, final String database, final String protocolVersion, String clientVersion, final boolean force, final Tls tls,
 		final Properties properties)
 	{
+		this.properties = properties;
+		resetLocalVars();
 		this.force = force;
 		this.url = url;
 		this.user = user;
@@ -336,12 +338,13 @@ public class XGConnection implements Connection
 		typeMap = new HashMap<>();
 		in = null;
 		out = null;
-		this.properties = properties;
 	}
 
 	public XGConnection(final String user, final String pwd, final String ip, final int portNum, final String url, final String database, final String protocolVersion, String clientVersion, final String force, final Tls tls,
 		final Properties properties) throws Exception
 	{
+		this.properties = properties;
+		resetLocalVars();
 		originalIp = ip;
 		originalPort = portNum;
 
@@ -363,7 +366,6 @@ public class XGConnection implements Connection
 		retryCounter = 0;
 		this.tls = tls;
 		typeMap = new HashMap<>();
-		this.properties = properties;
 	}
 
 	@Override
@@ -1621,7 +1623,7 @@ public class XGConnection implements Connection
 	 */
 	private Timer getTimer()
 	{
-		return timer.updateAndGet(existing -> existing != null ? existing : new Timer());
+		return timer.updateAndGet(existing -> existing != null ? existing : new Timer(true));
 	}
 
 	@Override

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -462,7 +462,7 @@ public class XGStatement implements Statement
 		this.conn = conn.copy(shouldRequestVersion);
 		force = false;
 		oneShotForce = false;
-		timeoutMillis = conn.getTimeoutMillis(); // inherit the connections timeout
+		timeoutMillis = this.conn.getTimeoutMillis(); // inherit the connections timeout
 	}
 
 	public XGStatement(final XGConnection conn, final boolean force, final boolean oneShotForce) throws SQLException
@@ -470,7 +470,7 @@ public class XGStatement implements Statement
 		this.conn = conn.copy();
 		this.force = force;
 		this.oneShotForce = oneShotForce;
-		timeoutMillis = conn.getTimeoutMillis(); // inherit the connections timeout
+		timeoutMillis = this.conn.getTimeoutMillis(); // inherit the connections timeout
 	}
 
 	public XGStatement(final XGConnection conn, final int type, final int concur, final boolean force, final boolean oneShotForce) throws SQLException
@@ -490,7 +490,7 @@ public class XGStatement implements Statement
 		this.conn = conn.copy();
 		this.force = force;
 		this.oneShotForce = oneShotForce;
-		timeoutMillis = conn.getTimeoutMillis(); // inherit the connections timeout
+		timeoutMillis = this.conn.getTimeoutMillis(); // inherit the connections timeout
 	}
 
 	public XGStatement(final XGConnection conn, final int type, final int concur, final int hold, final boolean force, final boolean oneShotForce) throws SQLException
@@ -517,7 +517,7 @@ public class XGStatement implements Statement
 		this.conn = conn.copy();
 		this.force = force;
 		this.oneShotForce = oneShotForce;
-		timeoutMillis = conn.getTimeoutMillis(); // inherit the connections timeout
+		timeoutMillis = this.conn.getTimeoutMillis(); // inherit the connections timeout
 	}
 
 	@Override
@@ -708,7 +708,6 @@ public class XGStatement implements Statement
 	public boolean execute(String sql) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Called execute()");
-		clearWarnings();
 		setRunningQueryThread(Thread.currentThread());
 		sql = sql.trim();
 
@@ -883,6 +882,7 @@ public class XGStatement implements Statement
 	public ResultSet executeQuery(String sql) throws SQLException
 	{
 		LOGGER.log(Level.INFO, String.format("Called executeQuery() with sql : %s", sql));
+		clearWarnings();
 		if (sql.charAt(0) == ' ' || sql.charAt(sql.length() - 1) == ' ')
 		{
 			sql = sql.trim();
@@ -1020,6 +1020,7 @@ public class XGStatement implements Statement
 	public int executeUpdate(String sql) throws SQLException
 	{
 		LOGGER.log(Level.INFO, String.format("Called executeUpdate() with sql: %s", sql));
+		clearWarnings();
 		// if this is a set command we just use a separately crafted proto message to
 		// make things simpler
 		passUpCancel(true);
@@ -2754,7 +2755,6 @@ public class XGStatement implements Statement
 						{
 							final Object parm = parms.get(x);
 
-							// System.out.println("parm type: " + parm.getClass());
 
 							if (parm == null)
 							{
@@ -2776,7 +2776,6 @@ public class XGStatement implements Statement
 							}
 							else if (parm instanceof Boolean)
 							{
-								// System.out.println("inside BOOLEAN set param");
 								out.append("BOOLEAN('").append(parm).append("')");
 							}
 							else if (parm instanceof byte[])

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,14 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 //tag::compact[] 
+== 2.13 (2021-6-17)
+
+New Features:: 
+
+ * Fix timeoutMillis by correctly inheriting timeoutMillis from properties.
+ * Clear warnings before running executeQuery and executeUpdate.
+
+//tag::compact[] 
 == 2.13 (2021-6-09)
 
 New Features:: 

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,7 +5,7 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 //tag::compact[] 
-== 2.13 (2021-6-17)
+== 2.14 (2021-6-17)
 
 New Features:: 
 


### PR DESCRIPTION
https://ocient.atlassian.net/browse/DB-17148
timeout was not working because we were not inheriting the property correctly.
https://ocient.atlassian.net/browse/DB-17113
was broken because we only cleared warnings in sendAndReceive. But certain execupteUpdates will not clear warning (set pso).