### PR TITLE
add openJump extension

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 genrule(
     name = "mvn_package",
-    srcs = glob(["src/**"]) + [
+    srcs = glob(["src/**","lib/**"]) + [
         "spotbugs-exclude.xml",
         "pom.xml",
     ],

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ocient</groupId>
   <artifactId>ocient-jdbc4</artifactId>
-  <version>2.21</version>
+  <version>2.22</version>
   <!--JDBC VERSION NUMBER HERE -->
   <name>${project.groupId}:${project.artifactId}</name>
   <description>JDBC Driver for connecting to an Ocient Database</description>
@@ -79,6 +79,19 @@
       <artifactId>jline-terminal-jansi</artifactId>
       <version>3.20.0</version>
     </dependency>
+		<dependency>
+			<groupId>org.openjump</groupId>
+			<artifactId>openjump-core</artifactId>
+			<version>20210701-r4865-SNAPSHOT</version>
+			<scope>system</scope>
+      <systemPath>${pom.basedir}/lib/OpenJUMP-20210701-r4865-nolang.jar</systemPath>
+		</dependency>
+		<dependency>
+			<groupId>org.locationtech.jts</groupId>
+			<artifactId>jts-core</artifactId>
+			<version>1.18.0</version>
+			<scope>provided</scope>
+		</dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -2191,7 +2191,7 @@ public class CLI
 						}
 						else
 						{
-							cmd += line;
+							cmd += line + " ";
 						}
 					}
 				}

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -2191,7 +2191,7 @@ public class CLI
 						}
 						else
 						{
-							cmd += line + " ";
+							cmd += (line + " ");
 						}
 					}
 				}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDSConnection.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDSConnection.java
@@ -1,0 +1,83 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.I18N;
+import com.vividsolutions.jump.datastore.AdhocQuery;
+import com.vividsolutions.jump.datastore.FilterQuery;
+import com.vividsolutions.jump.datastore.SpatialReferenceSystemID;
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesDSConnection;
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesSQLBuilder;
+import com.vividsolutions.jump.feature.FeatureSchema;
+import com.vividsolutions.jump.io.FeatureInputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class OcientDSConnection extends SpatialDatabasesDSConnection {
+
+    public OcientDSConnection(Connection con) {
+        super(con);
+        this.dbMetadata = new OcientDSMetadata(this);
+    }
+
+    @Override
+    public SpatialDatabasesSQLBuilder getSqlBuilder(SpatialReferenceSystemID srid, String[] colNames) {
+      return new OcientSQLBuilder(this.dbMetadata, srid, colNames);
+    }
+
+    /**
+     * Executes a filter query.
+     *
+     * The SRID is optional for queries - it will be determined automatically
+     * from the table metadata if not supplied.
+     *
+     * @param query the query to execute
+     * @return the results of the query
+     * @throws SQLException
+     */
+    @Override
+    public FeatureInputStream executeFilterQuery(FilterQuery query) throws SQLException {
+        SpatialReferenceSystemID srid = dbMetadata.getSRID(query.getDatasetName(), query.getGeometryAttributeName());
+        String[] colNames = dbMetadata.getColumnNames(query.getDatasetName());
+
+        OcientSQLBuilder builder = (OcientSQLBuilder)this.getSqlBuilder(srid, colNames);
+        String queryString = builder.getSQL(query);
+
+        return new OcientFeatureInputStream(connection, queryString, query.getPrimaryKey());
+    }
+
+    /**
+     * Executes an adhoc query.
+     *
+     * The SRID is optional for queries - it will be determined automatically
+     * from the table metadata if not supplied.
+     *
+     * @param query the query to execute
+     * @return the results of the query
+     * @throws SQLException
+     */
+    @Override
+    public FeatureInputStream executeAdhocQuery(AdhocQuery query) throws Exception {
+        String queryString = query.getQuery();
+        OcientFeatureInputStream ifs = new OcientFeatureInputStream(connection, queryString, query.getPrimaryKey());
+
+        FeatureSchema fs;
+        try {
+          fs = ifs.getFeatureSchema();
+        } catch (Exception e) {
+          throw new Exception(
+            I18N.get(SpatialDatabasesDSConnection.class.getName()                     
+                +".SQL-error") + e.getMessage());
+        }
+
+        if (fs.getGeometryIndex() < 0) {
+            throw new Exception(I18N.get(SpatialDatabasesDSConnection.class.getName()
+                +".resultset-must-have-a-geometry-column"));
+        }
+        return ifs;
+
+    }
+
+    public OcientValueConverterFactory getValueConverterFactory() {
+        return new OcientValueConverterFactory(connection);
+    }
+
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDSMetadata.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDSMetadata.java
@@ -1,0 +1,123 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.datastore.SQLUtil;
+import com.vividsolutions.jump.datastore.spatialdatabases.*;
+import com.vividsolutions.jump.datastore.DataStoreConnection;
+import com.vividsolutions.jump.datastore.GeometryColumn;
+import com.vividsolutions.jump.feature.AttributeType;
+
+import java.text.Normalizer;
+import java.util.List;
+
+public class OcientDSMetadata extends SpatialDatabasesDSMetadata {
+
+    public OcientDSMetadata(DataStoreConnection con) {
+        conn = con;
+        // TODO: use bind parameters to avoid SQL injection
+	String geometryColumnsDef = "(SELECT \n" +
+			"'' AS f_table_catalog, \n" +
+			"CASE WHEN t.schema = 'sysgdc' THEN SUBSTRING(t.name, 0, LOCATE('_', t.name)) ELSE t.schema END AS f_table_schema, \n" +
+			"CASE WHEN t.schema = 'sysgdc' THEN SUBSTRING(t.name, LOCATE('_', t.name) + 1) ELSE t.name END AS f_table_name, \n" +
+			"c.name AS f_geometry_column, \n" + 
+			"int(2) AS coord_dimension, \n" +
+			"int(4326) AS srid, \n" +
+			"CASE WHEN c.data_type = 'POINT(2)' THEN 'POINT' ELSE c.data_type END AS \"type\" \n" +
+			"FROM sys.columns c \n" +
+			"INNER JOIN sys.tables t \n" +
+			"ON c.table_id = t.id \n" +
+			"WHERE c.data_type IN ('POINT(2)', 'LINESTRING', 'POLYGON'))";
+
+	datasetNameQuery = "SELECT DISTINCT f_table_schema, f_table_name FROM " + geometryColumnsDef;
+        defaultSchemaName = "public";
+        spatialDbName = "Ocient";
+        // No safe way found to get layer's extent from database.
+        // text aggregation trick (select st_envelope(Geomfromtext(concat(concat(\"geometrycollection(\",group_concat(astext(%s))),\")\")))) from %s.%s)
+        // Use extent of first record only as an hint to layer location
+	String spatialExtentQuery1 = "select st_polygon(concat('POLYGON((', concat(STRING_AGG(points, ', '), '))')))\n" + 
+                                "FROM (\n" + 
+                                "  SELECT UNNEST(char[](\n" + 
+                                "    concat(minx, concat(' ', miny)),\n" + 
+                                "    concat(maxx, concat(' ', miny)),\n" + 
+                                "    concat(maxx, concat(' ', maxy)),\n" + 
+                                "    concat(minx, concat(' ', maxy)),\n" +  
+                                "    concat(minx, concat(' ', miny)))) as points\n" +  
+                                "    FROM (\n" + 
+                                "      SELECT\n" +
+                                "        min(st_x(st_pointN(geom, 1))) AS minx,\n" +
+                                "        min(st_y(st_pointN(geom, 1))) AS miny,\n" +
+                                "        max(st_x(st_pointN(geom, 3))) AS maxx,\n" +
+                                "        max(st_y(st_pointN(geom, 3))) AS maxy\n" +
+                                "            FROM (\n" +
+                                "              SELECT st_ExteriorRing(st_envelope(%s)) AS geom\n" +
+                                "                  FROM %s.%s\n" +
+                                "    )) AS t\n" +
+                                ") as t2";		       
+
+        // NO st_extent function defined yet => same query is defined.
+        spatialExtentQuery2 = spatialExtentQuery1;
+        geoColumnsQuery = "SELECT f_geometry_column, coord_dimension, srid, type FROM " + geometryColumnsDef + "  where f_table_schema='%s' and f_table_name = '%s'";
+        sridQuery = "SELECT srid FROM " + geometryColumnsDef + "  where f_table_schema = '%s' and f_table_name = '%s' and f_geometry_column = '%s'";
+        coordDimQuery = "SELECT coord_dimension FROM " + geometryColumnsDef + "  where f_table_schema = '%s' and f_table_name = '%s' and f_geometry_column = '%s'";
+        datasetInfoQuery = "SELECT f_table_schema, f_table_name, f_geometry_column, coord_dimension, srid, type FROM " + geometryColumnsDef + "  order by 1, 2";
+
+    }
+
+    @Override
+    public String getSpatialExtentQuery1(String schema, String table, String attributeName) {
+        //must escape single quote in idenfifiers before formatting query
+        return String.format(this.spatialExtentQuery1, 
+                SQLUtil.escapeSingleQuote(schema),
+                SQLUtil.escapeSingleQuote(table),
+                SQLUtil.escapeSingleQuote(attributeName));
+    }
+
+    @Override
+    public String getSpatialExtentQuery2(String schema, String table, String attributeName) {
+        return String.format(this.spatialExtentQuery2, attributeName, schema, table);
+    }
+
+    @Override
+    public String getGeoColumnsQuery(String datasetName) {
+        //must escape single quote in idenfifiers before formatting query
+        return String.format(this.geoColumnsQuery,
+                SQLUtil.escapeSingleQuote(getSchemaName(datasetName)),
+                SQLUtil.escapeSingleQuote(getTableName(datasetName)));
+    }
+
+    @Override
+    public String getSridQuery(String schemaName, String tableName, String colName) {
+        //must escape single quote in idenfifiers before formatting query
+        return String.format(this.sridQuery,
+                SQLUtil.escapeSingleQuote(schemaName),
+                SQLUtil.escapeSingleQuote(tableName),
+                SQLUtil.escapeSingleQuote(colName));
+    }
+
+    @Override
+    public List<GeometryColumn> getGeometryAttributes(String datasetName) {
+        String sql = this.getGeoColumnsQuery(datasetName);
+        return getGeometryAttributes(sql, datasetName);
+    }
+
+    @Override
+    public String getCoordinateDimensionQuery(String schemaName, String tableName, String colName) {
+        //must escape single quote in idenfifiers before formatting query
+        return String.format(this.coordDimQuery,
+                SQLUtil.escapeSingleQuote(schemaName),
+                SQLUtil.escapeSingleQuote(tableName),
+                SQLUtil.escapeSingleQuote(colName));
+    }
+
+    protected String getDbTypeName(AttributeType type) {
+        if (type == AttributeType.GEOMETRY)      return "char";
+        else if (type == AttributeType.STRING)   return "char";
+        else if (type == AttributeType.INTEGER)  return "integer";
+        else if (type == AttributeType.LONG)     return "bigint";
+        else if (type == AttributeType.DOUBLE)   return "double";
+        else if (type == AttributeType.NUMERIC)  return "decimal";
+        else if (type == AttributeType.DATE)     return "timestamp";
+        else if (type == AttributeType.BOOLEAN)  return "boolean";
+        else if (type == AttributeType.OBJECT)   return "binary";
+        else return "char";
+      }
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDataStoreDriver.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDataStoreDriver.java
@@ -1,0 +1,39 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.I18N;
+import com.vividsolutions.jump.JUMPVersion;
+import java.sql.Connection;
+
+import com.vividsolutions.jump.datastore.DataStoreConnection;
+import com.vividsolutions.jump.datastore.spatialdatabases.AbstractSpatialDatabasesDSDriver;
+import com.vividsolutions.jump.parameter.ParameterList;
+import java.util.Properties;
+
+/**
+ * A driver for supplying {@link com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesDSConnection}s
+ */
+public class OcientDataStoreDriver
+    extends AbstractSpatialDatabasesDSDriver {
+
+    public final static String JDBC_CLASS = "com.ocient.jdbc.JDBCDriver";
+
+    public OcientDataStoreDriver() {
+        this.driverName = "Ocient";
+        this.jdbcClass = JDBC_CLASS;
+        this.urlPrefix = "jdbc:ocient://";
+    }
+
+    /**
+     * returns the right type of DataStoreConnection
+     * @param params
+     * @return
+     * @throws Exception 
+     */
+    @Override
+    public DataStoreConnection createConnection(ParameterList params)
+        throws Exception {
+        Properties connectionProps = new Properties();
+        Connection conn = super.createJdbcConnection(params, connectionProps);
+        return new OcientDSConnection(conn);
+    }
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDatastorePlugIn.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDatastorePlugIn.java
@@ -1,0 +1,25 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.datastore.DataStoreDriver;
+import com.vividsolutions.jump.workbench.plugin.AbstractPlugIn;
+import com.vividsolutions.jump.workbench.plugin.PlugInContext;
+import java.sql.Driver;
+/**
+ * @author potocki
+ */
+public class OcientDatastorePlugIn extends AbstractPlugIn {
+
+    public OcientDatastorePlugIn() {
+    }
+
+    public void initialize(PlugInContext context) throws Exception {
+        try {
+            context.getWorkbenchContext().getRegistry().createEntry(DataStoreDriver.REGISTRY_CLASSIFICATION,
+                new OcientDataStoreDriver());
+            System.out.println("Ocient Data Store added");
+        } catch (Exception e) {
+            System.out.println("Ocient driver not found: " + e.toString() + ". Ocient Data Store NOT added");
+        }
+
+    }
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDatastorePlugInExtension.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientDatastorePlugInExtension.java
@@ -1,0 +1,21 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.workbench.plugin.Extension;
+import com.vividsolutions.jump.workbench.plugin.PlugInContext;
+/**
+ *
+ *  - this class loads the PlugIn into Jump <p>
+ *  - class has to be called "Extension" on the end of classname
+ *    to use the PlugIn in Jump
+ * 
+ *  @author potocki 
+ */
+public class OcientDatastorePlugInExtension extends Extension{
+
+	/**
+	 * calls PlugIn using class method xplugin.initialize() 
+	 */
+	public void configure(PlugInContext context) throws Exception{
+		new OcientDatastorePlugIn().initialize(context);
+	}	
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientFeatureInputStream.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientFeatureInputStream.java
@@ -1,0 +1,28 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesFeatureInputStream;
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesResultSetConverter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+public class OcientFeatureInputStream extends SpatialDatabasesFeatureInputStream {
+
+    public OcientFeatureInputStream(Connection conn, String queryString) {
+        this(conn, queryString, null);
+    }
+
+    public OcientFeatureInputStream(Connection conn, String queryString, String externalIdentifier) {
+        super(conn, queryString, externalIdentifier);
+    }
+
+    /**
+     * Returns a OcientResultSetConverter
+     * @param rs
+     * @return 
+     */
+    @Override
+    protected SpatialDatabasesResultSetConverter getResultSetConverter(ResultSet rs) {
+        return new OcientResultSetConverter(conn, rs);
+    }
+
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientResultSetConverter.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientResultSetConverter.java
@@ -1,0 +1,22 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesResultSetConverter;
+import com.vividsolutions.jump.feature.Feature;
+import com.vividsolutions.jump.feature.FeatureSchema;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+/**
+ * Implements the mapping between a result set and a {@link FeatureSchema} and
+ * {@link Feature} set.
+ *
+ * This is a transient worker class, whose lifetime should be no longer than the
+ * lifetime of the provided ResultSet
+ */
+public class OcientResultSetConverter extends SpatialDatabasesResultSetConverter {
+
+  public OcientResultSetConverter(Connection conn, ResultSet rs) {
+    this.rs = rs;
+    this.odm = new OcientValueConverterFactory(conn);
+  }
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientSQLBuilder.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientSQLBuilder.java
@@ -1,0 +1,110 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import org.locationtech.jts.geom.Envelope;
+import com.vividsolutions.jump.datastore.DataStoreLayer;
+import com.vividsolutions.jump.datastore.FilterQuery;
+import com.vividsolutions.jump.datastore.SpatialReferenceSystemID;
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesDSMetadata;
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesSQLBuilder;
+
+
+/**
+ * Creates SQL query strings for a Spatial database.
+ * To be overloaded by classes implementing a spatial database support.
+ */
+public class OcientSQLBuilder extends SpatialDatabasesSQLBuilder {
+
+  public OcientSQLBuilder(SpatialDatabasesDSMetadata dbMetadata, 
+      SpatialReferenceSystemID defaultSRID, String[] colNames) {
+    super(dbMetadata, defaultSRID, colNames);
+  }
+
+  /**
+   * Builds a valid SQL spatial query with the given spatial filter.
+   * @param query
+   * @return a SQL query to get column names
+   */
+  @Override
+  public String getSQL(FilterQuery query) {
+    StringBuilder qs = new StringBuilder();
+    //HACK
+    qs.append("SELECT ");
+    qs.append(getColumnListSpecifier(colNames, query.getGeometryAttributeName()));
+    qs.append(" FROM ");
+    // fixed by mmichaud on 2010-05-27 for mixed case dataset names
+    qs.append("\"").append(query.getDatasetName().replaceAll("\\.","\".\"")).append("\"");
+    qs.append(" t WHERE ");
+    qs.append(buildBoxFilter(query));
+
+    String whereCond = query.getCondition();
+    if (whereCond != null) {
+      qs.append(" AND ");
+      qs.append(whereCond);
+    }
+    int limit = query.getLimit();
+    if (limit != 0 && limit != Integer.MAX_VALUE) {
+      qs.append(" LIMIT ").append(limit);
+    }
+    //System.out.println(qs);
+    return qs.toString();
+  };
+
+  /**
+   * Returns the query allowing to test a DataStoreLayer: builds a query with where
+   * clause and limit 0 to check where clause.
+   * @return 
+   */
+  @Override
+  public String getCheckSQL(DataStoreLayer dsLayer) {
+    String s = "select * FROM %s %s LIMIT 0";
+    String wc = dsLayer.getWhereClause();
+    if (wc != null && ! wc.isEmpty()) {
+      wc = " WHERE " + wc ;
+    } else {
+      wc = "";
+    }
+    //System.out.println(qs);
+    return String.format(s, dsLayer.getFullName(), wc);
+  }
+
+  /**
+   * Returns the string representing a SQL column definition.
+   * Implementors should take care of column names (case, quotes)
+   * @param colNames
+   * @param geomColName
+   * @return column list
+   */
+  @Override
+  protected String getColumnListSpecifier(String[] colNames, String geomColName) {
+    // Added double quotes around each column name in order to read mixed case table names
+    // correctly [mmichaud 2007-05-13]
+    StringBuilder buf = new StringBuilder();
+    // fixed by mmichaud using a patch from jaakko [2008-05-21]
+    // query geomColName as geomColName instead of geomColName as geomColName + "_wkb"
+
+    // [mmichaud 2016-10-01] ST_AsEWKB is no more util and is not compatible with r5032
+    buf.append("\"").append(geomColName).append("\"");
+    for (String colName : colNames) {
+      if (! geomColName.equalsIgnoreCase(colName)) {
+        buf.append(",\"").append(colName).append("\"");
+      }
+    }
+    return buf.toString();
+  }
+
+  @Override
+  protected String buildBoxFilter(FilterQuery query) {
+    Envelope env = query.getFilterGeometry().getEnvelopeInternal();
+
+    // Example of Ocient SQL: where st_Intersects(b.geom, st_polygonFromText('POLYGON((4 4, 5 4, 5 5, 4 5, 4 4))'))
+    StringBuilder buf = new StringBuilder();
+    buf.append("st_intersects(").append(query.getGeometryAttributeName()).append(", st_polygonFromText('POLYGON((");
+    buf.append(env.getMinX()).append(" ").append(env.getMinY()).append(",")
+        .append(env.getMaxX()).append(" ").append(env.getMinY()).append(",")
+        .append(env.getMaxX()).append(" ").append(env.getMaxY()).append(",")
+        .append(env.getMinX()).append(" ").append(env.getMaxY()).append(",")
+        .append(env.getMinX()).append(" ").append(env.getMinY());
+    buf.append("))'))");
+    return buf.toString();
+  }
+}

--- a/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientValueConverterFactory.java
+++ b/src/main/java/org/openjump/core/ui/plugin/datastore/ocient/OcientValueConverterFactory.java
@@ -1,0 +1,39 @@
+package org.openjump.core.ui.plugin.datastore.ocient;
+
+import com.vividsolutions.jump.datastore.jdbc.ValueConverter;
+import com.vividsolutions.jump.datastore.jdbc.ValueConverterFactory;
+import com.vividsolutions.jump.datastore.spatialdatabases.SpatialDatabasesValueConverterFactory;
+import java.sql.Connection;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * Factory to convert Ocient geometric data type.
+ * 
+ */
+public class OcientValueConverterFactory extends SpatialDatabasesValueConverterFactory {
+
+  public OcientValueConverterFactory(Connection conn) {
+    super(conn);
+  }
+
+  @Override
+  public ValueConverter getConverter(ResultSetMetaData rsm, int columnIndex)
+      throws SQLException {
+    String dbTypeName = rsm.getColumnTypeName(columnIndex);
+
+    if ("st_point".equalsIgnoreCase(dbTypeName) ||
+    	"st_linestring".equalsIgnoreCase(dbTypeName) ||
+    	"st_polygon".equalsIgnoreCase(dbTypeName)) {
+      return WKT_GEOMETRY_MAPPER;
+    }
+
+    // handle the standard types
+    ValueConverter stdConverter = ValueConverterFactory.getConverter(rsm, columnIndex);
+    if (stdConverter != null) {
+      return stdConverter;
+    }
+        // default - can always show it as a string!
+    return ValueConverterFactory.STRING_MAPPER;
+  }
+}

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,7 +5,7 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 //tag::compact[]
-== 2.21 (2021-7-1)
+== 2.22 (2021-7-1)
 
 New Features::
 

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -10,6 +10,7 @@ Below is the release notes for every driver version that has customer implicatio
 New Features::
 
  * Add openJump extensions to jdbc jar.
+ * Fix source command for plan execute inline.
 
 //tag::compact[]
 == 2.21 (2021-6-30)

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,13 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 //tag::compact[]
+== 2.21 (2021-7-1)
+
+New Features::
+
+ * Add openJump extensions to jdbc jar.
+
+//tag::compact[]
 == 2.21 (2021-6-30)
 
 New Features::


### PR DESCRIPTION
https://ocient.atlassian.net/browse/DB-16935

This extends our driver to support openJump. Now, we just need to put this jar into the `lib/ext` directory of jump and it will be picked up. Note that we have two new dependencies, jts and the jump library itself. The tags are system and provided respectively. This means, that during build time, we will use them, but they will not become a part of the jar. It is up to the openJump / user to provide these at run time.