### PR TITLE
[DB-17420] fix set syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ocient</groupId>
   <artifactId>ocient-jdbc4</artifactId>
-  <version>2.25</version>
+  <version>2.26</version>
   <!--JDBC VERSION NUMBER HERE -->
   <name>${project.groupId}:${project.artifactId}</name>
   <description>JDBC Driver for connecting to an Ocient Database</description>

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
@@ -43,6 +42,7 @@ import com.ocient.jdbc.XGConnection;
 import com.ocient.jdbc.XGDatabaseMetaData;
 import com.ocient.jdbc.XGStatement;
 import com.ocient.jdbc.proto.ClientWireProtocol.SysQueriesRow;
+import com.ocient.jdbc.XGRegexUtils;
 
 public class CLI
 {
@@ -58,25 +58,7 @@ public class CLI
 
 	private static char quote = '\0';
 	private static boolean comment = false;
-
-	private static Pattern connectToSyntax = Pattern.compile(
-		"connect\\s+to\\s+(?<preurl>jdbc:ocient://?)(?<hosts>.+?)(?<posturl>/.+?)(?<up>\\s+user\\s+(" + userTk() + ")\\s+using\\s+(?<q>\"?)(?<pwd>.+?)\\k<q>)?(?<force>\\s+force)?",
-		Pattern.CASE_INSENSITIVE);
-
-	private static Pattern listTablesSyntax = Pattern.compile("list\\s+tables(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
-	private static Pattern listSystemTablesSyntax = Pattern.compile("list\\s+system\\s+tables(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
-	private static Pattern listViewsSyntax = Pattern.compile("list\\s+views(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
-	private static Pattern describeTableSyntax = Pattern.compile("describe(\\s+table\\s+)?((" + tk("schema") + ")\\.)?(" + tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
-	private static Pattern describeViewSyntax = Pattern.compile("describe(\\s+view\\s+)?((" + tk("schema") + ")\\.)?(" + tk("view") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
-	private static Pattern listIndexesSyntax = Pattern.compile("list\\s+ind(ic|ex)es\\s+((" + tk("schema") + ")\\.)?(" + tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
 	private static final char[] hexArray = "0123456789abcdef".toCharArray();
-
 	private static Statement stmt;
 
 	private static String bytesToHex(final byte[] bytes)
@@ -183,7 +165,7 @@ public class CLI
 
 		try
 		{
-			final Matcher m = connectToSyntax.matcher(cmd);
+			final Matcher m = XGRegexUtils.connectToSyntax.matcher(cmd);
 			if (!m.matches())
 			{
 				System.out.println("Syntax: connect to <jdbc url>( user <username> using <password>)?( force)?");
@@ -204,7 +186,7 @@ public class CLI
 				}
 				else
 				{
-					doConnect(getTk(m, "user", null), m.group("pwd"), m.group("force") != null, url);
+					doConnect(XGRegexUtils.getTk(m, "user", null), m.group("pwd"), m.group("force") != null, url);
 				}
 				// No exception thrown means connection was successful, and connectTo may return
 				stmt = conn.createStatement();
@@ -241,7 +223,7 @@ public class CLI
 
 		try
 		{
-			final Matcher m = describeTableSyntax.matcher(cmd);
+			final Matcher m = XGRegexUtils.describeTableSyntax.matcher(cmd);
 			if (!m.matches())
 			{
 				System.out.println("Syntax: describe (<schema>.)?<table>");
@@ -341,7 +323,7 @@ public class CLI
 
 		try
 		{
-			final Matcher m = describeViewSyntax.matcher(cmd);
+			final Matcher m = XGRegexUtils.describeViewSyntax.matcher(cmd);
 			if (!m.matches())
 			{
 				System.out.println("Syntax: describe view (<schema>.)?<view>");
@@ -802,22 +784,6 @@ public class CLI
 		}
 	}
 
-	// Get a token from its generated regex according to SQL case-sensitivity rules
-	// (sensitive iff quoted).
-	// Do not call on a matcher that has not yet called matches().
-	private static String getTk(final Matcher m, final String name, final String def)
-	{
-		if (m.group(name) == null)
-		{
-			return def;
-		}
-		if (m.group("q0" + name).length() == 0)
-		{
-			return m.group(name).toLowerCase();
-		}
-		return m.group(name);
-	}
-
 	private static boolean isConnected()
 	{
 		if (conn != null)
@@ -962,7 +928,7 @@ public class CLI
 
 		try
 		{
-			final Matcher m = listIndexesSyntax.matcher(cmd);
+			final Matcher m = XGRegexUtils.listIndexesSyntax.matcher(cmd);
 			if (!m.matches())
 			{
 				System.out.println("Syntax: list indexes (<schema>.)?<table>");
@@ -1157,7 +1123,7 @@ public class CLI
 
 		try
 		{
-			final Matcher m = isSystemTables ? listSystemTablesSyntax.matcher(cmd) : listTablesSyntax.matcher(cmd);
+			final Matcher m = isSystemTables ? XGRegexUtils.listSystemTablesSyntax.matcher(cmd) : XGRegexUtils.listTablesSyntax.matcher(cmd);
 			if (!m.matches())
 			{
 				// this line will never be reached,
@@ -1240,7 +1206,7 @@ public class CLI
 		{
 			final DatabaseMetaData md = conn.getMetaData();
 			final XGDatabaseMetaData dbmd = (XGDatabaseMetaData) md;
-			final Matcher m = listViewsSyntax.matcher(cmd);
+			final Matcher m = XGRegexUtils.listViewsSyntax.matcher(cmd);
 			if (!m.matches())
 			{
 				// this line will never be reached,
@@ -1719,7 +1685,7 @@ public class CLI
 	private static boolean processCommand(final String cmd)
 	{
 		boolean quit = false;
-		// System.out.println("processCommand(" + cmd + ")");
+		System.out.println("processCommand(" + cmd + ")");
 		if (cmd.equals(""))
 		{
 			return quit;
@@ -2232,15 +2198,6 @@ public class CLI
 		return false;
 	}
 
-	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
-	// (.) token. Reluctant.
-	// Do not insert multiple regexes for tokens of the same name (or "q0" + another
-	// name) into a single pattern.
-	private static String tk(final String name)
-	{
-		return "(?<q0" + name + ">\"?)(?<" + name + ">(\\w+?|(?<=\").+?(?=\")))\\k<q0" + name + ">";
-	}
-
 	private static void update(final String cmd)
 	{
 		long start = 0;
@@ -2266,13 +2223,5 @@ public class CLI
 		{
 			System.out.println("Error: " + e.getMessage());
 		}
-	}
-
-	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
-	// (.) token possibly followed
-	// by @ and more unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free (.) tokens.
-	private static String userTk()
-	{
-		return "(?<q0user>\"?)(?<user>(\\w+?|(?<=\").+?(?=\"))(@(\\w+?|(?<=\").+?(?=\")))?)\\k<q0user>";
 	}
 }

--- a/src/main/java/com/ocient/cli/CLI.java
+++ b/src/main/java/com/ocient/cli/CLI.java
@@ -1685,7 +1685,7 @@ public class CLI
 	private static boolean processCommand(final String cmd)
 	{
 		boolean quit = false;
-		System.out.println("processCommand(" + cmd + ")");
+		// System.out.println("processCommand(" + cmd + ")");
 		if (cmd.equals(""))
 		{
 			return quit;

--- a/src/main/java/com/ocient/jdbc/XGRegexUtils.java
+++ b/src/main/java/com/ocient/jdbc/XGRegexUtils.java
@@ -43,6 +43,8 @@ public class XGRegexUtils{
     
     // Syntax is set <optionName> <optionValue>;
     // Option value can be quoted or unquoted. Unquoted values can only be alphanumeric
+    // This creates a pattern using the specified option name allows for the matcher
+    // to extract the option value. We use this for the general class of set commands.
     public static Matcher genericSetSyntaxMatch(final String optionName, final String cmd) 
     {
         String regex = "set\\s+" + optionName + "\\s+" + XGRegexUtils.tk(optionName);

--- a/src/main/java/com/ocient/jdbc/XGRegexUtils.java
+++ b/src/main/java/com/ocient/jdbc/XGRegexUtils.java
@@ -14,7 +14,6 @@ public class XGRegexUtils{
 	public static Pattern listIndexesSyntax = Pattern.compile("list\\s+ind(ic|ex)es\\s+((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
 	public static Pattern describeTableSyntax = Pattern.compile("describe(\\s+table\\s+)?((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
 	public static Pattern describeViewSyntax = Pattern.compile("describe(\\s+view\\s+)?((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("view") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);    
-    public static Pattern setSchemaSyntax = Pattern.compile("set\\s+schema\\s+" + XGRegexUtils.tk("schema"));
 
 
     // Get a token from its generated regex according to SQL case-sensitivity rules
@@ -40,7 +39,16 @@ public class XGRegexUtils{
 	public static String tk(final String name)
 	{
 		return "(?<q0" + name + ">\"?)(?<" + name + ">(\\w+?|(?<=\").+?(?=\")))\\k<q0" + name + ">";
-	}    
+	}   
+    
+    // Syntax is set <optionName> <optionValue>;
+    // Option value can be quoted or unquoted. Unquoted values can only be alphanumeric
+    public static Matcher genericSetSyntaxMatch(final String optionName, final String cmd) 
+    {
+        String regex = "set\\s+" + optionName + "\\s+" + XGRegexUtils.tk(optionName);
+        Pattern genericSetSyntax = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        return genericSetSyntax.matcher(cmd);
+    }
 
 	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
 	// (.) token possibly followed

--- a/src/main/java/com/ocient/jdbc/XGRegexUtils.java
+++ b/src/main/java/com/ocient/jdbc/XGRegexUtils.java
@@ -14,6 +14,7 @@ public class XGRegexUtils{
 	public static Pattern listIndexesSyntax = Pattern.compile("list\\s+ind(ic|ex)es\\s+((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
 	public static Pattern describeTableSyntax = Pattern.compile("describe(\\s+table\\s+)?((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
 	public static Pattern describeViewSyntax = Pattern.compile("describe(\\s+view\\s+)?((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("view") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);    
+    public static Pattern setSchemaSyntax = Pattern.compile("set\\s+schema\\s+" + XGRegexUtils.tk("schema"));
 
 
     // Get a token from its generated regex according to SQL case-sensitivity rules

--- a/src/main/java/com/ocient/jdbc/XGRegexUtils.java
+++ b/src/main/java/com/ocient/jdbc/XGRegexUtils.java
@@ -1,0 +1,52 @@
+package com.ocient.jdbc;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XGRegexUtils{
+
+	public static Pattern connectToSyntax = Pattern.compile(
+		"connect\\s+to\\s+(?<preurl>jdbc:ocient://?)(?<hosts>.+?)(?<posturl>/.+?)(?<up>\\s+user\\s+(" + userTk() + ")\\s+using\\s+(?<q>\"?)(?<pwd>.+?)\\k<q>)?(?<force>\\s+force)?",
+		Pattern.CASE_INSENSITIVE);    
+
+	public static Pattern listTablesSyntax = Pattern.compile("list\\s+tables(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
+    public static Pattern listSystemTablesSyntax = Pattern.compile("list\\s+system\\s+tables(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
+	public static Pattern listViewsSyntax = Pattern.compile("list\\s+views(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
+	public static Pattern listIndexesSyntax = Pattern.compile("list\\s+ind(ic|ex)es\\s+((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
+	public static Pattern describeTableSyntax = Pattern.compile("describe(\\s+table\\s+)?((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
+	public static Pattern describeViewSyntax = Pattern.compile("describe(\\s+view\\s+)?((" + XGRegexUtils.tk("schema") + ")\\.)?(" + XGRegexUtils.tk("view") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);    
+
+
+    // Get a token from its generated regex according to SQL case-sensitivity rules
+	// (sensitive iff quoted).
+	// Do not call on a matcher that has not yet called matches().
+	public static String getTk(final Matcher m, final String name, final String def)
+	{
+		if (m.group(name) == null)
+		{
+			return def;
+		}
+		if (m.group("q0" + name).length() == 0)
+		{
+			return m.group(name).toLowerCase();
+		}
+		return m.group(name);
+	}
+
+	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
+	// (.) token. Reluctant.
+	// Do not insert multiple regexes for tokens of the same name (or "q0" + another
+	// name) into a single pattern.
+	public static String tk(final String name)
+	{
+		return "(?<q0" + name + ">\"?)(?<" + name + ">(\\w+?|(?<=\").+?(?=\")))\\k<q0" + name + ">";
+	}    
+
+	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
+	// (.) token possibly followed
+	// by @ and more unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free (.) tokens.
+	private static String userTk()
+	{
+		return "(?<q0user>\"?)(?<user>(\\w+?|(?<=\").+?(?=\"))(@(\\w+?|(?<=\").+?(?=\")))?)\\k<q0user>";
+	}    
+
+}

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -2574,7 +2574,6 @@ public class XGStatement implements Statement
 	private int setParallelismSQL(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setParallelism()");
-		// final String ending = cmd.toUpperCase().substring("SET PARALLELISM ".length()).trim();
 		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("parallelism", cmd);
 		if (!m.matches())
 		{

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -2574,8 +2574,14 @@ public class XGStatement implements Statement
 	private int setParallelismSQL(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setParallelism()");
-		final String ending = cmd.toUpperCase().substring("SET PARALLELISM ".length()).trim();
-		final boolean reset = ending.equals("RESET");
+		// final String ending = cmd.toUpperCase().substring("SET PARALLELISM ".length()).trim();
+		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("parallelism", cmd);
+		if (!m.matches())
+		{
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set parallelism syntax: set parallelism <parallelismValue>");
+		}
+		String ending = XGRegexUtils.getTk(m, "parallelism", "");		
+		final boolean reset = ending.toUpperCase().equals("RESET");
 		int parallelism = 0;
 		try
 		{
@@ -2668,8 +2674,13 @@ public class XGStatement implements Statement
 	private int setMaxRowsSQL(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setMaxRows()");
-		final String ending = cmd.toUpperCase().substring("SET MAXROWS ".length()).trim();
-		final boolean reset = ending.equals("RESET");
+		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("maxrows", cmd);
+		if (!m.matches())
+		{
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set maxrows syntax: set maxrows <maxrowValue>");
+		}
+		final String ending = XGRegexUtils.getTk(m, "maxrows", "");
+		final boolean reset = ending.toUpperCase().equals("RESET");
 		int maxRows = 0;
 		try
 		{
@@ -2684,8 +2695,13 @@ public class XGStatement implements Statement
 	private int setMaxTempDiskSQL(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setMaxTempDisk()");
-		final String ending = cmd.toUpperCase().substring("SET MAXTEMPDISK ".length()).trim();
-		final boolean reset = ending.equals("RESET");
+		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("maxtempdisk", cmd);
+		if (!m.matches())
+		{
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set maxtempdisk syntax: set maxtempdisk <maxtempdiskValue>");
+		}
+		final String ending = XGRegexUtils.getTk(m, "maxtempdisk", "");
+		final boolean reset = ending.toUpperCase().equals("RESET");
 		int maxTempDisk = 0;
 		try
 		{
@@ -2700,8 +2716,13 @@ public class XGStatement implements Statement
 	private int setMaxTimeSQL(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setMaxTime()");
-		final String ending = cmd.toUpperCase().substring("SET MAXTIME ".length()).trim();
-		final boolean reset = ending.equals("RESET");
+		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("maxtime", cmd);
+		if (!m.matches())
+		{
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set maxtime syntax: set maxtime <maxtimeValue>");
+		}
+		final String ending = XGRegexUtils.getTk(m, "maxtime", "");
+		final boolean reset = ending.toUpperCase().equals("RESET");
 		int maxTime = 0;
 		try
 		{
@@ -2913,8 +2934,13 @@ public class XGStatement implements Statement
 	private int setPrioritySQL(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setPriority()");
-		final String ending = cmd.toUpperCase().substring("SET PRIORITY ".length()).trim();
-		final boolean reset = ending.equals("RESET");
+		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("priority", cmd);
+		if (!m.matches())
+		{
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set priority syntax: set priority <priorityValue>");
+		}
+		String ending = XGRegexUtils.getTk(m, "priority", "");		
+		final boolean reset = ending.toUpperCase().equals("RESET");
 		double priority = 0;
 		try
 		{
@@ -2957,10 +2983,10 @@ public class XGStatement implements Statement
 	private int setSchema(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setSchema()");
-		final Matcher m = XGRegexUtils.setSchemaSyntax.matcher(cmd);
+		final Matcher m = XGRegexUtils.genericSetSyntaxMatch("schema", cmd);
 		if (!m.matches())
 		{
-			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set schema syntax: set schema <schema>");
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set schema syntax: set schema <schemaValue>");
 		}
 		String schema = XGRegexUtils.getTk(m, "schema", "");
 		conn.setSchema(schema);

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -2957,18 +2957,12 @@ public class XGStatement implements Statement
 	private int setSchema(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's setSchema()");
-		String schema = cmd.substring(11).trim();
-		if (schema.startsWith("\""))
+		final Matcher m = XGRegexUtils.setSchemaSyntax.matcher(cmd);
+		if (!m.matches())
 		{
-			if (!schema.endsWith("\""))
-			{
-				throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Uncloseed Quotes!");
-			}
-
-			schema = schema.substring(1, schema.length() - 1);
-		} else {
-			schema = schema.toLowerCase();
+			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax error. Proper set schema syntax: set schema <schema>");
 		}
+		String schema = XGRegexUtils.getTk(m, "schema", "");
 		conn.setSchema(schema);
 		return 0;
 	}

--- a/src/main/java/com/ocient/jdbc/XGStatement.java
+++ b/src/main/java/com/ocient/jdbc/XGStatement.java
@@ -37,7 +37,6 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.google.common.base.Preconditions;
 import com.ocient.jdbc.proto.ClientWireProtocol;
@@ -63,6 +62,7 @@ import com.ocient.jdbc.proto.ClientWireProtocol.SystemWideCompletedQueries;
 import com.ocient.jdbc.proto.ClientWireProtocol.SystemWideQueries;
 
 import com.ocient.jdbc.KML;
+import com.ocient.jdbc.XGRegexUtils;
 
 public class XGStatement implements Statement
 {
@@ -95,14 +95,6 @@ public class XGStatement implements Statement
 	private static final int defaultFetchSize = 30000;
 
 	private static HashMap<XGConnection, HashSet<XGStatement>> cache = new HashMap<>();
-
-	private static Pattern listTablesSyntax = Pattern.compile("list\\s+tables(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-
-	private static Pattern listSystemTablesSyntax = Pattern.compile("list\\s+system\\s+tables(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-	private static Pattern listViewsSyntax = Pattern.compile("list\\s+views(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-	private static Pattern listIndexesSyntax = Pattern.compile("list\\s+ind(ic|ex)es\\s+((" + tk("schema") + ")\\.)?(" + tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-	private static Pattern describeTableSyntax = Pattern.compile("describe(\\s+table\\s+)?((" + tk("schema") + ")\\.)?(" + tk("table") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
-	private static Pattern describeViewSyntax = Pattern.compile("describe(\\s+view\\s+)?((" + tk("schema") + ")\\.)?(" + tk("view") + ")(?<verbose>\\s+verbose)?", Pattern.CASE_INSENSITIVE);
 	
 	public static void setKMLFile(final String cmd) {
 		try
@@ -133,22 +125,6 @@ public class XGStatement implements Statement
 	{
 		final int ret = java.nio.ByteBuffer.wrap(val).getInt();
 		return ret;
-	}
-
-	// Get a token from its generated regex according to SQL case-sensitivity rules
-	// (sensitive iff quoted).
-	// Do not call on a matcher that has not yet called matches().
-	private static String getTk(final Matcher m, final String name, final String def)
-	{
-		if (m.group(name) == null)
-		{
-			return def;
-		}
-		if (m.group("q0" + name).length() == 0)
-		{
-			return m.group(name).toLowerCase();
-		}
-		return m.group(name);
 	}
 
 	public void returnStatementToCache(){
@@ -411,15 +387,6 @@ public class XGStatement implements Statement
 		return false;
 	}
 
-	// Generate a regex for an unquoted alphanumeric ([a-zA-Z0-9_]) or quoted free
-	// (.) token. Reluctant.
-	// Do not insert multiple regexes for tokens of the same name (or "q0" + another
-	// name) into a single pattern.
-	private static String tk(final String name)
-	{
-		return "(?<q0" + name + ">\"?)(?<" + name + ">(\\w+?|(?<=\").+?(?=\")))\\k<q0" + name + ">";
-	}
-
 	protected boolean poolable = true;
 
 	protected boolean closed = false;
@@ -675,27 +642,27 @@ public class XGStatement implements Statement
 	{
 		LOGGER.log(Level.INFO, "Entered driver's describeTable()");
 		final ResultSet rs = null;
-		final Matcher m = describeTableSyntax.matcher(cmd);
+		final Matcher m = XGRegexUtils.describeTableSyntax.matcher(cmd);
 		if (!m.matches())
 		{
 			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax: describe (<schema>.)?<table>");
 		}
 		final DatabaseMetaData dbmd = conn.getMetaData();
-		return dbmd.getColumns("", getTk(m, "schema", conn.getSchema()), getTk(m, "table", null), "%");
+		return dbmd.getColumns("", XGRegexUtils.getTk(m, "schema", conn.getSchema()), XGRegexUtils.getTk(m, "table", null), "%");
 	}
 
 	private ResultSet describeView(final String cmd) throws SQLException
 	{
 		LOGGER.log(Level.INFO, "Entered driver's describeView()");
 		final ResultSet rs = null;
-		final Matcher m = describeViewSyntax.matcher(cmd);
+		final Matcher m = XGRegexUtils.describeViewSyntax.matcher(cmd);
 		if (!m.matches())
 		{
 			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax: describe view (<schema>.)?<view>");
 		}
 		final DatabaseMetaData md = conn.getMetaData();
 		final XGDatabaseMetaData dbmd = (XGDatabaseMetaData) md;
-		return dbmd.getViews("", getTk(m, "schema", conn.getSchema()), getTk(m, "view", null), null);
+		return dbmd.getViews("", XGRegexUtils.getTk(m, "schema", conn.getSchema()), XGRegexUtils.getTk(m, "view", null), null);
 	}
 
 	/** Dissociate the current query with this statement */
@@ -2161,14 +2128,14 @@ public class XGStatement implements Statement
 	{
 		LOGGER.log(Level.INFO, "Entered driver's listIndexes()");
 		final ResultSet rs = null;
-		final Matcher m = listIndexesSyntax.matcher(cmd);
+		final Matcher m = XGRegexUtils.listIndexesSyntax.matcher(cmd);
 
 		if (!m.matches())
 		{
 			throw SQLStates.SYNTAX_ERROR.cloneAndSpecify("Syntax: list indexes (<schema>.)?<table>");
 		}
 		final DatabaseMetaData dbmd = conn.getMetaData();
-		return dbmd.getIndexInfo("", getTk(m, "schema", conn.getSchema()), getTk(m, "table", null), false, false);
+		return dbmd.getIndexInfo("", XGRegexUtils.getTk(m, "schema", conn.getSchema()), XGRegexUtils.getTk(m, "table", null), false, false);
 	}
 
 	// used by CLI
@@ -2189,7 +2156,7 @@ public class XGStatement implements Statement
 		LOGGER.log(Level.INFO, "Entered driver's listTables()");
 		ResultSet rs = null;
 
-		final Matcher m = isSystemTables ? listSystemTablesSyntax.matcher(cmd) : listTablesSyntax.matcher(cmd);
+		final Matcher m = isSystemTables ? XGRegexUtils.listSystemTablesSyntax.matcher(cmd) : XGRegexUtils.listTablesSyntax.matcher(cmd);
 		if (!m.matches())
 		{
 			// this line will never be reached,
@@ -2215,7 +2182,7 @@ public class XGStatement implements Statement
 		LOGGER.log(Level.INFO, "Entered driver's listViews()");
 		final ResultSet rs = null;
 
-		final Matcher m = listViewsSyntax.matcher(cmd);
+		final Matcher m = XGRegexUtils.listViewsSyntax.matcher(cmd);
 		if (!m.matches())
 		{
 			// this line will never be reached,

--- a/userdoc/release_notes.adoc
+++ b/userdoc/release_notes.adoc
@@ -5,6 +5,15 @@ All our jdbc drivers are located {drivers_repo}[here].
 Below is the release notes for every driver version that has customer implication.
 
 //tag::compact[]
+== 2.26 (2021-7-30)
+
+New Features::
+
+ * Move the duplicated regex code in CLI.java and XGStatement.java into a new file.
+ * Implement a generic regex for syntax checking the set family of sql commands.
+ * Fix a bug in resetting commands using lower cases. "set maxrow reset;" does not work. Needs to be capitalized.
+
+//tag::compact[]
 == 2.25 (2021-7-27)
 
 New Features::


### PR DESCRIPTION
https://ocient.atlassian.net/browse/DB-17420

1. Move the duplicated regex code in `CLI.java` and `XGStatement.java` into a new file.
2. Implement a generic regex for syntax checking the set family of sql commands.
3. Fix a bug in resetting commands using lower cases. set maxrow reset; does not work if. Needs to be capitalized. 